### PR TITLE
Limit search by geocoordinates

### DIFF
--- a/classes/OccurrenceManager.php
+++ b/classes/OccurrenceManager.php
@@ -414,6 +414,10 @@ class OccurrenceManager extends OccurrenceTaxaManager {
 			$sqlWhere .= "AND (o.occid IN(SELECT occid FROM omoccurgenetic)) ";
 			$this->displaySearchArr[] = 'has genetic data';
 		}
+		if(array_key_exists("hascoords",$this->searchTermArr)){
+			$sqlWhere .= "AND (o.decimalLatitude IS NOT NULL) ";
+			$this->displaySearchArr[] = 'has geocoorindates';
+		}
 		if($sqlWhere){
 			if(!array_key_exists("includecult",$this->searchTermArr)){
 				$sqlWhere .= "AND (o.cultivationStatus IS NULL OR o.cultivationStatus = 0) ";

--- a/classes/OccurrenceManager.php
+++ b/classes/OccurrenceManager.php
@@ -416,7 +416,7 @@ class OccurrenceManager extends OccurrenceTaxaManager {
 		}
 		if(array_key_exists("hascoords",$this->searchTermArr)){
 			$sqlWhere .= "AND (o.decimalLatitude IS NOT NULL) ";
-			$this->displaySearchArr[] = 'has geocoorindates';
+			$this->displaySearchArr[] = 'has geocoordinates';
 		}
 		if($sqlWhere){
 			if(!array_key_exists("includecult",$this->searchTermArr)){

--- a/classes/OccurrenceManager.php
+++ b/classes/OccurrenceManager.php
@@ -828,6 +828,14 @@ class OccurrenceManager extends OccurrenceTaxaManager {
 				unset($this->searchTermArr["hasgenetic"]);
 			}
 		}
+		if(array_key_exists("hascoords",$_REQUEST)){
+			if($_REQUEST["hascoords"]){
+				$this->searchTermArr["hascoords"] = true;
+			}
+			else{
+				unset($this->searchTermArr["hascoords"]);
+			}
+		}
 		if(array_key_exists("includecult",$_REQUEST)){
 			if($_REQUEST["includecult"]){
 				$this->searchTermArr["includecult"] = true;

--- a/collections/harvestparams.php
+++ b/collections/harvestparams.php
@@ -242,6 +242,9 @@ $searchVar = $collManager->getQueryTermStr();
 				<input type='checkbox' name='hasgenetic' value='1' /> <?php echo isset($LANG['HAS_GENETIC'])?$LANG['HAS_GENETIC']:'Limit to Specimens with Genetic Data Only'; ?>
 			</div>
 			<div>
+				<input type='checkbox' name='hascoords' value='1' /> <?php echo isset($LANG['HAS_COORDS'])?$LANG['HAS_COORDS']:'Limit to Specimens with Geocoordinates Only'; ?>
+			</div>
+			<div>
 				<input type='checkbox' name='includecult' value='1' /> <?php echo isset($LANG['INCLUDE_CULTIVATED'])?$LANG['INCLUDE_CULTIVATED']:'Include cultivated/captive occurrences'; ?>
 			</div>
 			<div>

--- a/content/lang/collections/harvestparams.en.php
+++ b/content/lang/collections/harvestparams.en.php
@@ -56,5 +56,6 @@ $LANG['INCLUDE_OTHER_CATNUM'] = 'Include other catalog numbers and GUIDs';
 $LANG['TYPE'] = 'Limit to Type Specimens';
 $LANG['HAS_IMAGE'] = 'Limit to Specimens with Images';
 $LANG['HAS_GENETIC'] = 'Limit to Specimens with Genetic Data';
+$LANG['HAS_COORDS'] = 'Limit to Specimens with Geocoordinates';
 $LANG['INCLUDE_CULTIVATED'] = 'Include cultivated/captive occurrences';
 ?>

--- a/content/lang/collections/harvestparams.es.php
+++ b/content/lang/collections/harvestparams.es.php
@@ -56,5 +56,6 @@ $LANG['INCLUDE_OTHER_CATNUM'] = 'Includa todos n&uacute;meros de cat&eacute;logo
 $LANG['TYPE'] = 'Limitar a ejemplares tipo';
 $LANG['HAS_IMAGE'] = 'Limitar a ejemplares con im&aacute;genes';
 $LANG['HAS_GENETIC'] = 'Limitar a ejemplares con datos gen&eacute;ticos';
+$LANG['HAS_COORDS'] = 'Limitar a ejemplares con coordenadas geogr&aacute;ficas';
 $LANG['INCLUDE_CULTIVATED'] = 'Incluye ejemplares cultivadas/cautivas';
 ?>

--- a/js/symb/collections.harvestparams.js
+++ b/js/symb/collections.harvestparams.js
@@ -16,7 +16,7 @@ function checkHarvestParamsForm(frm){
 	if((frm.taxa.value.trim() == '') && (frm.country.value.trim() == '') && (frm.state.value.trim() == '') && (frm.county.value.trim() == '') &&
 		(frm.local.value.trim() == '') && (frm.elevlow.value.trim() == '') && (frm.upperlat.value.trim() == '') && (frm.footprintwkt.value.trim() == '') && (frm.pointlat.value.trim() == '') &&
 		(frm.collector.value.trim() == '') && (frm.collnum.value.trim() == '') && (frm.eventdate1.value.trim() == '') && (frm.catnum.value.trim() == '') &&
-		(frm.typestatus.checked == false) && (frm.hasimages.checked == false) && (frm.hasgenetic.checked == false)){
+		(frm.typestatus.checked == false) && (frm.hasimages.checked == false) && (frm.hasgenetic.checked == false) && (frm.hascoords.checked == false)){
 		alert("Please fill in at least one search parameter!");
 		return false;
 	}
@@ -112,6 +112,7 @@ function setHarvestParamsForm(){
 		if(typeof urlVar.typestatus !== 'undefined'){frm.typestatus.checked = true;}
 		if(typeof urlVar.hasimages !== 'undefined'){frm.hasimages.checked = true;}
 		if(typeof urlVar.hasgenetic !== 'undefined'){frm.hasgenetic.checked = true;}
+		if(typeof urlVar.hascoords !== 'undefined'){frm.hascoords.checked = true;}
 		if(typeof urlVar.includecult !== 'undefined'){frm.includecult.checked = true;}
 		if(urlVar.db){frm.db.value = urlVar.db;}
 	}


### PR DESCRIPTION
Ed,
Here is the new specimen criterion for limiting a non-map search to only specimens with lat/long. I looked at your code for restricting this on vouchers (Line 66, OccurrenceManager.php) and adopted the SQL you used of just checking if decimalLatitude is not null.
Let me know if you see anything I should change.
--Chris