### PR TITLE
Fixes logic bug for resizing Large images

### DIFF
--- a/classes/ImageLocalProcessor.php
+++ b/classes/ImageLocalProcessor.php
@@ -646,11 +646,28 @@ class ImageLocalProcessor {
 					// 1 = import source
 					if($width > ($this->webPixWidth*1.3)){
 						//Source image is big enough to serve as large version
-						if($width > $this->lgPixWidth || ($fileSize && $fileSize > $this->lgFileSizeLimit)){
-							//Image is too width or file size is too big, thus let's resize and import
+						if($width > $this->lgPixWidth){
+							//Image is too wide, thus let's resize and import
 							if($this->createNewImage($sourcePath.$fileName,$targetPath.$lgTargetFileName,$this->lgPixWidth,round($this->lgPixWidth*$height/$width),$width,$height)){
 								$lgUrl = $lgTargetFileName;
 								$this->logOrEcho("Resized source as large derivative (".date('Y-m-d h:i:s A').") ",1);
+							}
+						}
+						elseif($fileSize && $fileSize > $this->lgFileSizeLimit) {
+							// Image file size is too big, thus let's resize and import
+
+							// Figure out what factor to reduce filesize by
+							$ratio = $filesize / $this->lgFileSizeLimit;
+
+							// Scale by a factor of the square root of the filesize ratio
+							// Note, this is a good approximation to reduce the filesize, but will not be exact
+							// True reduction will also depend on the JPEG quality of the source & the large file
+							$newWidth = round($width * sqrt($ratio));
+
+							// Resize the image
+							if($this->createNewImage($sourcePath.$fileName,$targetPath.$lgTargetFileName,$newWidth,round($newWidth*$height/$width),$width,$height)){
+								$lgUrlFrag = $this->imgUrlBase.$targetFrag.$lgTargetFileName;
+							$this->logOrEcho("Resized source as large derivative (".date('Y-m-d h:i:s A').") ",1);
 							}
 						}
 						else{


### PR DESCRIPTION
- Previously, files that exceeded either the large file pixel width limit or the large filesize limit were treated together, and a new large image with the maximum pixel dimensions was generated in either case.
- However, the result of this is that if a source image's filesize was too large (but not it's pixel width), the image would be *upscaled*, resulting in an even larger filesize.
- The fix treats these two cases separately, and proportionately downscales files with filesizes that are too big. The resulting file won't exactly match the maximum filesize, but will approximate it. 