### PR TITLE
Adds Doesn't Contain to Occurrence Editor search

### DIFF
--- a/classes/OccurrenceEditorManager.php
+++ b/classes/OccurrenceEditorManager.php
@@ -506,6 +506,14 @@ class OccurrenceEditorManager {
 						$sqlWhere .= 'AND ('.$cf.' LIKE "%'.$cv.'%") ';
 					}
 				}
+				elseif($ct=='NOT LIKE' && $cv){
+					if(strpos($cv,'%') !== false){
+						$sqlWhere .= 'AND ('.$cf.' NOT LIKE "'.$cv.'") ';
+					}
+					else{
+						$sqlWhere .= 'AND ('.$cf.' NOT LIKE "%'.$cv.'%") ';
+					}
+				}
 				elseif($ct=='STARTS' && $cv){
 					if(strpos($cv,'%') !== false){
 						$sqlWhere .= 'AND ('.$cf.' LIKE "'.$cv.'") ';

--- a/collections/editor/includes/queryform.php
+++ b/collections/editor/includes/queryform.php
@@ -203,6 +203,7 @@ else{
 					<option <?php echo ($qCustomType1=='NOT EQUALS'?'SELECTED':''); ?> value="NOT EQUALS">NOT EQUALS</option>
 					<option <?php echo ($qCustomType1=='STARTS'?'SELECTED':''); ?> value="STARTS">STARTS WITH</option>
 					<option <?php echo ($qCustomType1=='LIKE'?'SELECTED':''); ?> value="LIKE">CONTAINS</option>
+					<option <?php echo ($qCustomType1=='NOT LIKE'?'SELECTED':''); ?> value="NOT LIKE">DOESN'T CONTAIN</option>
 					<option <?php echo ($qCustomType1=='GREATER'?'SELECTED':''); ?> value="GREATER">GREATER THAN</option>
 					<option <?php echo ($qCustomType1=='LESS'?'SELECTED':''); ?> value="LESS">LESS THAN</option>
 					<option <?php echo ($qCustomType1=='NULL'?'SELECTED':''); ?> value="NULL">IS NULL</option>
@@ -229,6 +230,7 @@ else{
 					<option <?php echo ($qCustomType2=='NOT EQUALS'?'SELECTED':''); ?> value="NOT EQUALS">NOT EQUALS</option>
 					<option <?php echo ($qCustomType2=='STARTS'?'SELECTED':''); ?> value="STARTS">STARTS WITH</option>
 					<option <?php echo ($qCustomType2=='LIKE'?'SELECTED':''); ?> value="LIKE">CONTAINS</option>
+					<option <?php echo ($qCustomType2=='NOT LIKE'?'SELECTED':''); ?> value="NOT LIKE">DOESN'T CONTAIN</option>
 					<option <?php echo ($qCustomType2=='GREATER'?'SELECTED':''); ?> value="GREATER">GREATER THAN</option>
 					<option <?php echo ($qCustomType2=='LESS'?'SELECTED':''); ?> value="LESS">LESS THAN</option>
 					<option <?php echo ($qCustomType2=='NULL'?'SELECTED':''); ?> value="NULL">IS NULL</option>
@@ -255,6 +257,7 @@ else{
 					<option <?php echo ($qCustomType3=='NOT EQUALS'?'SELECTED':''); ?> value="NOT EQUALS">NOT EQUALS</option>
 					<option <?php echo ($qCustomType3=='STARTS'?'SELECTED':''); ?> value="STARTS">STARTS WITH</option>
 					<option <?php echo ($qCustomType3=='LIKE'?'SELECTED':''); ?> value="LIKE">CONTAINS</option>
+					<option <?php echo ($qCustomType3=='NOT LIKE'?'SELECTED':''); ?> value="NOT LIKE">DOESN'T CONTAIN</option>
 					<option <?php echo ($qCustomType3=='GREATER'?'SELECTED':''); ?> value="GREATER">GREATER THAN</option>
 					<option <?php echo ($qCustomType3=='LESS'?'SELECTED':''); ?> value="LESS">LESS THAN</option>
 					<option <?php echo ($qCustomType3=='NULL'?'SELECTED':''); ?> value="NULL">IS NULL</option>


### PR DESCRIPTION
This allows for additional NOT style searches in addition to the pre-existing NOT EQUALS, NOT NULL, etc.

*For example:*
- Records without a certain person in the list associated collectors
- Records without a particular phenology, locality, habitat string, etc.

On the back end, this just adds a query WHERE option for NOT LIKE %...%