### PR TITLE
Use ImageMagic for resize, if configured

### DIFF
--- a/collections/specprocessor/processor.php
+++ b/collections/specprocessor/processor.php
@@ -20,6 +20,8 @@ $procStatus = array_key_exists('procstatus',$_REQUEST)?$_REQUEST['procstatus']:'
 
 $specManager = new SpecProcessorManager();
 $specManager->setCollId($collid);
+// Use ImageMagick, if so configured in symbini.php
+$specManager->setUseImageMagick($USE_IMAGE_MAGICK ? $USE_IMAGE_MAGICK : 0);
 
 $isEditor = false;
 if($IS_ADMIN || (array_key_exists("CollAdmin",$USER_RIGHTS) && in_array($collid,$USER_RIGHTS["CollAdmin"]))){


### PR DESCRIPTION
Allows for use of ImageMagick for resizing images on import
- There's a configuration option for whether to use ImageMagick in symbini.php, but it is not used in the image processing script.
- This allows collections/specprocessor/processor.php to utilize that setting to set whether to use ImageMagick or GD for image resizing.

Though requiring extra server configuration, ImageMagick has some advantages: speed, lower memory usage, smaller filesizes, and better quality resizing, especially noticeable on thumbnail images.