### PR TITLE
fixes issue for portals using hybrids indicated by multiplication sign

### DIFF
--- a/classes/APITaxonomy.php
+++ b/classes/APITaxonomy.php
@@ -13,10 +13,10 @@ class APITaxonomy extends Manager{
 
 	public function getTaxon($sciname){
 		$retArr = array();
-		$sciname = preg_replace('/[^a-zA-Z\-\. ]+/', '', $sciname);
+		$sciname = preg_replace('/[^a-zA-Z\-\.× ]+/', '', $sciname);
 		$sql = 'SELECT tid, sciname, author FROM taxa WHERE (sciname = "'.$sciname.'")';
 		if(preg_match('/\s{1}\D{1}\s{1}/i',$sciname)){
-			$sciname = preg_replace('/\s{1}x{1}\s{1}/i', ' _ ', $sciname);
+			$sciname = preg_replace('/\s{1}x{1}\s{1}|\s{1}×{1}\s{1}/i', ' _ ', $sciname);
 			$sql = 'SELECT tid, sciname, author FROM taxa WHERE (sciname LIKE "'.$sciname.'")';
 		}
 		$rs = $this->conn->query($sql);


### PR DESCRIPTION
- In CCH2, when an user was trying to add a hybrid species to a checklist, there was an error searching for that `sciname` in the database, since the API was expecting only a regular "x" character, and not a multiplication sign (×, \u00D7).
- I've added the multiplication sign as an exception in the regex cleaning the `sciname` used for searching the database.