### PR TITLE
Enter scientific names with genus/species/infra abbreviations

### DIFF
--- a/classes/OccurrenceEditorServices.php
+++ b/classes/OccurrenceEditorServices.php
@@ -46,7 +46,7 @@ class OccurrenceEditorServices {
 		$sql .= 'ORDER BY sciname';
 
 		// If the search term has an infraspecific separator, use the old version of the SQL, otherwise, no matches will be returned
-		if(array_intersect($strArr, array("var.", "ssp.", "f.", "×", "x"))) $sql = 'SELECT DISTINCT tid, sciname FROM taxa WHERE sciname LIKE "'.$term.'%" ';
+		if(array_intersect($strArr, array("var.", "ssp.", "nothossp." "f.", "×", "x"))) $sql = 'SELECT DISTINCT tid, sciname FROM taxa WHERE sciname LIKE "'.$term.'%" ';
 
 		$rs = $this->conn->query($sql);
 		while ($r = $rs->fetch_object()){

--- a/classes/OccurrenceEditorServices.php
+++ b/classes/OccurrenceEditorServices.php
@@ -46,7 +46,7 @@ class OccurrenceEditorServices {
 		$sql .= 'ORDER BY sciname';
 
 		// If the search term has an infraspecific separator, use the old version of the SQL, otherwise, no matches will be returned
-		if(array_intersect($strArr, array("var.", "ssp.", "nothossp." "f.", "×", "x"))) $sql = 'SELECT DISTINCT tid, sciname FROM taxa WHERE sciname LIKE "'.$term.'%" ';
+		if(array_intersect($strArr, array("var.", "ssp.", "nothossp." "f.", "×", "x", "†"))) $sql = 'SELECT DISTINCT tid, sciname FROM taxa WHERE sciname LIKE "'.$term.'%" ';
 
 		$rs = $this->conn->query($sql);
 		while ($r = $rs->fetch_object()){


### PR DESCRIPTION
This adds species entry shortcuts for entering scientific names in data editor tools (occurrence editor, skeletal entry, etc). For example, `pse men gla `will match _Pseudotsuga menziesii_ ssp. _glauca_. It will work with a variable number of letters for each part of a name, and will match any level taxon down to infraspecific taxa.

This functionality is already present in the Associated Taxa field of the occurrence editor, and I've implemented it similarly.

However, as implemented in the Associated Taxa field, it would not match a search term containing an infraspecific taxon indicator, or a hybrid symbol e.g., "_Pseudotsuga menziesii_ ssp." or "× _Agropogon_". The code searches for ssp., var., f., and x (also x), and falls back to searching the full scientific name field in those cases.