### PR TITLE
Fixed language bug in listtabledisplay.php

### DIFF
--- a/collections/listtabledisplay.php
+++ b/collections/listtabledisplay.php
@@ -244,7 +244,7 @@ $searchVar = $collManager->getQueryTermStr();
 					</table>
 					<div style="clear:both;height:5px;"></div>
 					<div style="width:790px;"><?php echo $navStr; ?></div>
-					*<?php echo (isset($LANG['CLICK_SYMB'])?$LANG['SYMB_ID']:'Click on the Symbiota identifier in the first column to see Full Record Details'); ?>.';
+					*<?php echo (isset($LANG['CLICK_SYMB'])?$LANG['CLICK_SYMB']:'Click on the Symbiota identifier in the first column to see Full Record Details'); ?>.';
 					<?php
 				}
 				else{

--- a/content/lang/collections/listtabledisplay.en.php
+++ b/content/lang/collections/listtabledisplay.en.php
@@ -26,7 +26,7 @@ $LANG['DEC_LAT'] = 'Decimal Lat.';
 $LANG['DEC_LONG'] = 'Decimal Long.';
 $LANG['EDIT_REC'] = 'Edit Record';
 $LANG['HAS_IMAGE'] = 'Has Image';
-$LANG['SYMB_ID'] = 'Click on the Symbiota identifier in the first column to see Full Record Details';
+$LANG['CLICK_SYMB'] = 'Click on the Symbiota identifier in the first column to see Full Record Details';
 $LANG['NONE_FOUND'] = 'No records found matching the query';
 
 

--- a/content/lang/collections/listtabledisplay.fr.php
+++ b/content/lang/collections/listtabledisplay.fr.php
@@ -27,7 +27,7 @@ $LANG['DEC_LAT'] = 'Lat. Décimale';
 $LANG['DEC_LONG'] = 'Long. Décimale';
 $LANG['EDIT_REC'] = 'Modifier';
 $LANG['HAS_IMAGE'] = 'A Image';
-$LANG['SYMB_ID'] = "Cliquez sur l'Identifiant Symbiota dans la première colonne pour voir les détails complets de l'enregistrement";
+$LANG['CLICK_SYMB'] = "Cliquez sur l'Identifiant Symbiota dans la première colonne pour voir les détails complets de l'enregistrement";
 $LANG['NONE_FOUND'] = 'Aucun enregistrement trouvé correspondant à la requête';
 
 ?>


### PR DESCRIPTION
$LANG['SYMB_ID'] was duplicated in the language files, second instance should have been $LANG['CLICK_SYMB'].

The result was displaying the help message as a column header instead of Symbiota ID