### PR TITLE
Moved heading inside innertext div in Occurrence Comment Listing

### DIFF
--- a/collections/misc/commentlist.php
+++ b/collections/misc/commentlist.php
@@ -121,8 +121,8 @@ if($isEditor){
 		}
 		?>
 		<!-- This is inner text! -->
-		<h1><?php echo $collMeta['name']; ?></h1>
 		<div id="innertext">
+			<h1><?php echo $collMeta['name']; ?></h1>
 			<?php
 			if($collid){
 				$pageBar = '';


### PR DESCRIPTION
This matches other pages. Previously, it was in between the navpath div and the innertext div.