### PR TITLE
implements dependencies for fetching tooltips from external api

### DIFF
--- a/classes/DocsUtilities.php
+++ b/classes/DocsUtilities.php
@@ -1,0 +1,38 @@
+<?php
+
+class DocsUtilities
+{
+    /**
+     * Class that supports fetching documentation and tooltips for Symbiota pages and tools.
+     * Methods depend on external documentation API.
+     */
+
+    public function getFilePath($magicFilePath, $serverRootPath)
+    {
+        /**
+         * $magicFilePath String __FILE__ (in file where it's being called, or full file url)
+         * $serverRootPath String equivalent to server root url ($SERVER_ROOT in most pages)
+         */
+
+        $filePath = str_replace("\\", "/", $magicFilePath);
+        $filePathStart = strpos($filePath, $serverRootPath);
+        $filePathEnd = strlen($serverRootPath);
+        $relFilePath = substr($filePath, $filePathEnd);
+        return $relFilePath;
+    }
+    
+    public function getTooltip($term)
+    {
+        /**
+         * $term String to be searched in documentation API:
+         * - in the case of a page it's the file path (without client path) file name with extension (for instance: '/collections/index.php');
+         * - in the case of a term, the term itself (for instance: 'Darwin Core Standard').
+         */
+        $url = 'https://biokic.github.io/symbiota-tooltips/api/'.$term.'.json';
+        $data = file_get_contents($url);
+        $tooltip = json_decode($data);
+        return $tooltip[0]->tooltip;
+    }
+}    
+    
+    

--- a/css/symb/tooltips.css
+++ b/css/symb/tooltips.css
@@ -1,0 +1,4 @@
+h1.page-title,
+.tooltip-container {
+  display: inline-block;
+}

--- a/includes/head_w_tooltips_template.php
+++ b/includes/head_w_tooltips_template.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * Customize styling by adding or modifying CSS file links below
+ * Default styling for individual page is defined within /css/symb/
+ * Individual styling can be customized by:
+ *     1) Uncommenting the $CUSTOM_CSS_PATH variable below
+ *     2) Copying individual CCS file to the /css/symb/custom directory
+ *     3) Modifying the sytle definiation within the file
+ */
+
+//$CUSTOM_CSS_PATH = '/css/symb/custom';
+?>
+<meta name="viewport" content="initial-scale=1.0, user-scalable=yes" />
+<?php
+if($activateJQuery){
+	//For an alternate jQuery UI styling, point link below to another css file
+	echo '<link href="'.$CLIENT_ROOT.'/css/jquery-ui.css" type="text/css" rel="stylesheet">';
+}
+?>
+<link href="<?php echo $CLIENT_ROOT; ?>/css/base.css?ver=1" type="text/css" rel="stylesheet">
+<link href="<?php echo $CLIENT_ROOT; ?>/css/symb/main.css?ver=1" type="text/css" rel="stylesheet">
+<!-- Symbiota Tooltips -->
+<link href="<?php echo $CLIENT_ROOT; ?>/css/symb/tooltips.css?ver=1" type="text/css" rel="stylesheet">
+<script src="<?php echo $CLIENT_ROOT; ?>/js/symb/symbiota.tooltips.js" defer></script>
+<script type="text/javascript">
+  document.addEventListener("DOMContentLoaded", async function(){
+    const relFilePath = <?php echo (json_encode($relFilePath)); ?>;
+    const langTag = <?php echo (json_encode($LANG_TAG)); ?>;
+    // console.log('relfilepath ' + relFilePath);
+    const pageTooltipText = await getTooltip(relFilePath, langTag);
+    const pageTitle = document.querySelector('#innertext h1');
+    addTooltip(pageTitle.parentNode, pageTooltipText);
+  })
+</script>

--- a/js/symb/symbiota.tooltips.js
+++ b/js/symb/symbiota.tooltips.js
@@ -1,0 +1,42 @@
+/**
+ * Fetches tooltip and documentation from external API
+ * Symbiota Tooltips (https://github.com/BioKIC/symbiota-tooltips)
+ */
+
+async function getTooltip(term, langTag) {
+  const apiUrl =
+    'https://biokic.github.io/symbiota-tooltips/api' + term + '.json';
+  // let tooltipText = '';
+  // tooltipText = await (fetch(url));
+  let tooltipText = '';
+  const res = await fetch(apiUrl);
+  if (res.status === 404) {
+    console.log('The requested tooltip does not exist.');
+  } else {
+    const data = await res.json();
+    tooltipText = data[0].tooltip[langTag];
+  }
+  return tooltipText;
+}
+
+/**
+ * Adds tooltip div adjacent to element
+ * @param {*} element
+ * @param {*} tooltipText
+ * @returns
+ */
+function addTooltip(element, tooltipText) {
+  console.log(tooltipText != '');
+  console.log(tooltipText);
+  if (tooltipText != '') {
+    const tooltip = document.createElement('div');
+    tooltip.className = 'tooltip-container';
+    tooltip.innerHTML =
+      '?<span class="tooltip-text">' + tooltipText + '</span>';
+    // element.appendChild(tooltip);
+    element.parentNode.insertBefore(tooltip, element.nextSibling);
+    console.log(element);
+  } else {
+    return;
+  }
+}


### PR DESCRIPTION
- Adds method to async fetch in head.php and output tooltip in desired pages
- When added to pages (along with an `<h1 class='page-title'>` page title block, automatically tries to fetch from [symbiota-tooltips API](https://github.com/BioKIC/symbiota-tooltips)
- Currently implementing fetching on selected terms on demand in pages