### PR TITLE
Fix reorderElements bug. Remove duplicate determination date divs

### DIFF
--- a/collections/individual/domManipulationUtils.js
+++ b/collections/individual/domManipulationUtils.js
@@ -13,12 +13,13 @@ const addElemFirst = (parentDivId, targetChildDivId) => {
 const reorderElements = (parentDivId, desiredDivIds, removeDivIds) => {
   const parent = document.getElementById(parentDivId);
   const allChildren = Array.from(parent.children);
-
-  allChildren.forEach((childEl) => {
-    const currentId = childEl.id;
-    if (desiredDivIds.includes(currentId)) {
+  const allChildrenIds = allChildren.map(child=>child.id);
+  desiredDivIds.forEach((currentId) => {
+    const desiredEl = document.getElementById(currentId);
+    if(!desiredEl) return;
+    if (allChildrenIds.includes(currentId)) {
       currentChildIdxInDesiredList = desiredDivIds.indexOf(currentId);
-      parent.appendChild(childEl);
+      parent.appendChild(desiredEl);
       if (desiredDivIds[currentChildIdxInDesiredList + 1] === "hr") {
         const hrElement = document.createElement("hr");
         hrElement.style.cssText = "margin-bottom: 2rem; clear: both;";
@@ -26,7 +27,7 @@ const reorderElements = (parentDivId, desiredDivIds, removeDivIds) => {
       }
     }
     if (removeDivIds.includes(currentId)) {
-      childEl.remove();
+      desiredEl.remove();
     }
   });
 };

--- a/collections/individual/domManipulationUtils.js
+++ b/collections/individual/domManipulationUtils.js
@@ -13,7 +13,7 @@ const addElemFirst = (parentDivId, targetChildDivId) => {
 const reorderElements = (parentDivId, desiredDivIds, removeDivIds) => {
   const parent = document.getElementById(parentDivId);
   const allChildren = Array.from(parent.children);
-  const allChildrenIds = allChildren.map(child=>child.id);
+  const allChildrenIds = allChildren?.map(child=>child.id) || [];
   desiredDivIds.forEach((currentId) => {
     const desiredEl = document.getElementById(currentId);
     if(!desiredEl) return;

--- a/collections/individual/index.php
+++ b/collections/individual/index.php
@@ -578,6 +578,12 @@ $traitArr = $indManager->getTraitArr();
 												if($detArr['qualifier']) echo $detArr['qualifier'];
 												echo ' <label><i>'.$detArr['sciname'].'</i></label> '.$detArr['author'];
 												?>
+												<div id="identby-div" class="identby-div">
+													<?php
+													echo '<label>'.(isset($LANG['DETERMINER'])?$LANG['DETERMINER']:'Determiner').': </label>';
+													echo $detArr['identifiedby'];
+													?>
+												</div>
 												<div id="identdate-div" class="identdate-div">
 													<?php
 													echo '<label>'.$LANG['DATE'].': </label>';

--- a/collections/individual/index.php
+++ b/collections/individual/index.php
@@ -325,6 +325,9 @@ $traitArr = $indManager->getTraitArr();
 		}
 		#exsiccati-div{ clear: both; }
 		#rights-div{ clear: both; }
+		.danger{ 
+			color: var(--danger-color);
+		}
 		<?php
 		if($shouldUseMinimalMapHeader){
 			?>
@@ -624,7 +627,7 @@ $traitArr = $indManager->getTraitArr();
 							<div id="typestatus-div" class="bottom-breathing-room-rel-sm">
 								<?php
 								echo '<label>'.$LANG['TYPE_STATUS'].': </label>';
-								echo '<span style="color: var(--danger-color)">' . $occArr['typestatus'] . '</span>';
+								echo '<span class="danger">' . $occArr['typestatus'] . '</span>';
 								?>
 							</div>
 							<?php

--- a/collections/individual/index.php
+++ b/collections/individual/index.php
@@ -178,6 +178,7 @@ $traitArr = $indManager->getTraitArr();
 	<link href="<?= $CSS_BASE_PATH ?>/symbiota/collections/individual/popup.css" type="text/css" rel="stylesheet" >
 	<script src="<?= $CLIENT_ROOT; ?>/js/jquery-3.7.1.min.js" type="text/javascript"></script>
 	<script src="<?= $CLIENT_ROOT; ?>/js/jquery-ui.min.js" type="text/javascript"></script>
+	<script src="<?php echo $CLIENT_ROOT . '/collections/individual/domManipulationUtils.js'; ?>" type="text/javascript"></script>
 	<script type="text/javascript">
 		var tabIndex = <?= $tabIndex; ?>;
 		var map;
@@ -514,11 +515,11 @@ $traitArr = $indManager->getTraitArr();
 								?>
 							</div>
 							<?php if($occArr['dateidentified']): ?>
-								<div id="identby-div" class="identby-div bottom-breathing-room-rel-sm">
-								<?php
-									echo '<label>'.$LANG['DATE_DET']  . ': '. '</label>' . $occArr['dateidentified'];
-								?>
-							</div>
+								<div id="identdate-div" class="identby-div bottom-breathing-room-rel-sm">
+									<?php
+										echo '<label>'.$LANG['DATE_DET']  . ': '. '</label>' . $occArr['dateidentified'];
+									?>
+								</div>
 							<?php endif; ?>
 							<?php
 						}
@@ -577,12 +578,6 @@ $traitArr = $indManager->getTraitArr();
 												if($detArr['qualifier']) echo $detArr['qualifier'];
 												echo ' <label><i>'.$detArr['sciname'].'</i></label> '.$detArr['author'];
 												?>
-												<div id="identby-div" class="identby-div">
-													<?php
-													echo '<label>'.(isset($LANG['DETERMINER'])?$LANG['DETERMINER']:'Determiner').': </label>';
-													echo $detArr['identifiedby'];
-													?>
-												</div>
 												<div id="identdate-div" class="identdate-div">
 													<?php
 													echo '<label>'.$LANG['DATE'].': </label>';
@@ -623,7 +618,7 @@ $traitArr = $indManager->getTraitArr();
 							<div id="typestatus-div" class="bottom-breathing-room-rel-sm">
 								<?php
 								echo '<label>'.$LANG['TYPE_STATUS'].': </label>';
-								echo $occArr['typestatus'];
+								echo '<span style="color: var(--danger-color)">' . $occArr['typestatus'] . '</span>';
 								?>
 							</div>
 							<?php


### PR DESCRIPTION
# Description

This PR fixes a bug in the `reorderElements` method in collections/individual/domManipulationUtils.js. This fix, along with a change of one of the div element id names, should address the following points from #2679 :

> The 'Date determined' field has moved to the very top of the page; needs to go below 'Determiner'
> 'Type status' has moved to the very bottom; should be right above 'Taxon' 
> In the NA, BARC, BPI, and ARSEF collections the 'Occurrence ID' is blank, but shows up in the new BBSL collection

It also adds a new local styling class and attaches it to the Type status element, satisfying:

> (Also, if possible/easy, it would be great to also make it stand out by changing it to red or something!)

I'm open to the above color fix not being a product-wide fix. Thoughts?


Note that these changes will only be visible in branches that have the following code snippet in collections/individual/index.php (like the usda branches, but not Development or master):

```
<script type="text/javascript">
		document.addEventListener('DOMContentLoaded', ()=>{
			reorderElements("occur-div", ["cat-div", "br", "preparations-div", "disposition-div", "sampleprotocol-div", "assoccatnum-parent-div" , "othercatalognumbers", "assoccatnum-div", "br", "association-div", "typestatus-div", "sciname-div", "idqualifier-div", "family-div", "br", "taxonremarks-div", "idqualifier-div","identref-div","identremarks-div", "determination-div", "br", "identby-div", "identdate-div", "br", "recordedby-div", "recordnumber-div","br", "eventdate-div", "verbeventid-div", "br", "cultivation-status-div", "locality-div", "latlng-div", "verbcoord-div", "elev-div", "habitat-div", "assoctaxa-div", "substrate-div", "sex-div", "lifestage-div", "reproductive-div", "attr-div", "indcnt-div", "notes-div", "br", "rights-div", "contact-div", "openeditor-div", "br", "record-id-div"], ["occurrenceid-div", "disposition-div"]);
		});
	</script>
```

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
    - #2679 
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
