### PR TITLE
Fix bug in verifyIconImage where it was getting element's wrong ID

### DIFF
--- a/collections/misc/collmetadata.php
+++ b/collections/misc/collmetadata.php
@@ -196,12 +196,12 @@ $collManager->cleanOutArr($collData);
 		}
 
 		function verifyIconImage(f) {
-			var iconImageFile = document.getElementById("iconfile").value;
+			var iconImageFile = document.getElementById("iconFile").value;
 			if (iconImageFile) {
 				var iconExt = iconImageFile.substr(iconImageFile.length - 4);
 				iconExt = iconExt.toLowerCase();
 				if ((iconExt != '.jpg') && (iconExt != 'jpeg') && (iconExt != '.png') && (iconExt != '.gif')) {
-					document.getElementById("iconfile").value = '';
+					document.getElementById("iconFile").value = '';
 					alert("<?php echo $LANG['NOT_SUPP'] ?>");
 				} else {
 					var fr = new FileReader;
@@ -209,14 +209,14 @@ $collManager->cleanOutArr($collData);
 						var img = new Image;
 						img.onload = function() {
 							if ((img.width > 500) || (img.height > 500)) {
-								document.getElementById("iconfile").value = '';
+								document.getElementById("iconFile").value = '';
 								img = '';
 								alert("<?php echo $LANG['MUST_SMALL'] ?>");
 							}
 						};
 						img.src = fr.result;
 					};
-					fr.readAsDataURL(document.getElementById("iconfile").files[0]);
+					fr.readAsDataURL(document.getElementById("iconFile").files[0]);
 				}
 			}
 		}


### PR DESCRIPTION
# Description

Caught this during the security audit of collections/misc/collmetadata.php. The `verifyIconImage` was not doing its job because the id of the iconFile element is `iconFile` rather than `iconfile`.

# QA Notes

In the Hotfix-3.3.4 branch, you should be able to upload any filetype as the icon (e.g., word, pdf, etc.). In this PR branch,  you should no longer be able to.

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [ ] Comment which GitHub issue(s), if any does this PR address
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
