### PR TITLE
Feature/S3 Support

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -601,6 +601,8 @@ class Media {
 						]
 					];
 
+					self::insertMediaMetadata($media_metadata['mediaID'], 'originalUrl', $file['size'], md5_file($file['tmp_name']));
+
 					foreach($urls as $url => $data) {
 						if(!($media_metadata[$url] ?? false)) {
 							$temp_path = UploadUtil::getTempDir() . $data['name'];
@@ -626,9 +628,12 @@ class Media {
 								$createdFilepaths[$url] = $storage->getDirPath($data['name']);
 							}
 
+							self::insertMediaMetadata($media_metadata['mediaID'], $url, filesize($temp_path), md5_file($temp_path));
+
 							unlink($temp_path);
 						}
 					}
+
 					$storage->upload($file);
 					$createdFilepaths['originalUrl'] = $storage->getDirPath($file);
 					self::update_metadata($metadata, $media_metadata['mediaID'], $conn);
@@ -641,12 +646,14 @@ class Media {
 				}
 			}
 
+/*
 			foreach($createdFilepaths as $field => $filepath) {
 				if(file_exists($filepath)) {
 					self::insertMediaMetadata($media_metadata['mediaID'], $field, filesize($filepath), md5_file($filepath));
 				}
 			}
 
+*/
 			mysqli_commit($conn);
 		} catch(Throwable $th) {
 			mysqli_rollback($conn);

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -1164,12 +1164,10 @@ class Media {
 				QueryUtil::executeQuery($conn, $query, [$media_id]);
 			}
 
-			$storage = StorageFactory::make();
-
 			//Unlink all files
 			if($remove_files) {
-				$root_url = self::getMediaRootUrl();
-				$root_path = self::getMediaRootPath();
+				$storage = StorageFactory::make();
+
 				foreach($media_urls as $url) {
 					if($url && $storage->file_exists($url)) {
 						if(!$storage->remove($url)) {

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -605,11 +605,8 @@ class Media {
 
 					foreach($urls as $url => $data) {
 						if(!($media_metadata[$url] ?? false)) {
-							$temp_path = UploadUtil::getTempDir() . $data['name'];
-
-							if(!is_writable($temp_path)) {
-								throw new MediaException(MediaException::FilepathNotWritable, $temp_path);
-							}
+							$tmp = tmpfile();
+							$temp_path = stream_get_meta_data($tmp)['uri'];
 
 							self::create_image(
 								$file['tmp_name'],

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -634,16 +634,14 @@ class Media {
 						}
 					}
 
-					$storage->upload($file);
 					$createdFilepaths['originalUrl'] = $storage->getDirPath($file);
 					self::update_metadata($metadata, $media_metadata['mediaID'], $conn);
-				} elseif($media_type === MediaType::Audio) {
-					$storage->upload($file);
-					$createdFilepaths['originalUrl'] = $storage->getDirPath($file);
-				} elseif($media_type === MediaType::Misc) {
-					$storage->upload($file);
-					$createdFilepaths['originalUrl'] = $storage->getDirPath($file);
 				}
+
+				// Upload and Cleanup temporary file
+				$storage->upload($file);
+				$createdFilepaths['originalUrl'] = $storage->getDirPath($file);
+				unlink($file['tmp_name']);
 			}
 
 /*

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -644,14 +644,6 @@ class Media {
 				unlink($file['tmp_name']);
 			}
 
-/*
-			foreach($createdFilepaths as $field => $filepath) {
-				if(file_exists($filepath)) {
-					self::insertMediaMetadata($media_metadata['mediaID'], $field, filesize($filepath), md5_file($filepath));
-				}
-			}
-
-*/
 			mysqli_commit($conn);
 		} catch(Throwable $th) {
 			mysqli_rollback($conn);

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -603,9 +603,13 @@ class Media {
 
 					foreach($urls as $url => $data) {
 						if(!($media_metadata[$url] ?? false)) {
+							$temp_path = $GLOBALS['SERVER_ROOT'] . '/temp/' . $data['name'];
+
+							// TODO (Logan) clean up temp files on failure
 							self::create_image(
 								$file['tmp_name'],
-								$storage->getDirPath($data['name']),
+								$temp_path,
+								// $storage->getDirPath($data['name']),
 								$data['width'],
 								$data['height']
 							);
@@ -614,7 +618,8 @@ class Media {
 							if(!$storage->file_exists($data['name'])) {
 								$storage->upload([
 									'name' => $data['name'],
-									'tmp_name' => $storage->getDirPath($data['name']),
+									'tmp_name' => $temp_path,
+									'type' => $file['type'],
 								]);
 							}
 

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -588,11 +588,7 @@ class Media {
 					$width = $size[0];
 					$height = $size[1];
 
-
-					$storage->upload($file);
-					$createdFilepaths['originalUrl'] = $storage->getDirPath($file);
-
-					$urls = [
+					$urls = [ 
 						'thumbnailUrl' => [
 							'name' => self::addToFilename($file['name'], '_tn'),
 							'width' => $GLOBALS['IMG_TN_WIDTH']?? 200,
@@ -608,7 +604,7 @@ class Media {
 					foreach($urls as $url => $data) {
 						if(!($media_metadata[$url] ?? false)) {
 							self::create_image(
-								$storage->getDirPath($file['name']),
+								$file['tmp_name'],
 								$storage->getDirPath($data['name']),
 								$data['width'],
 								$data['height']
@@ -629,7 +625,8 @@ class Media {
 
 						}
 					}
-
+					$storage->upload($file);
+					$createdFilepaths['originalUrl'] = $storage->getDirPath($file);
 					self::update_metadata($metadata, $media_metadata['mediaID'], $conn);
 				} elseif($media_type === MediaType::Audio) {
 					$storage->upload($file);

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -608,12 +608,19 @@ class Media {
 					foreach($urls as $url => $data) {
 						if(!($media_metadata[$url] ?? false)) {
 							self::create_image(
-								$file['name'],
-								$data['name'],
-								$storage,
+								$storage->getDirPath($file['name']),
+								$storage->getDirPath($data['name']),
 								$data['width'],
 								$data['height']
 							);
+
+							//If file doesn't according to the upload strategy then upload it to the correct place. This will only run if the media storage is remote to the server
+							if(!$storage->file_exists($data['name'])) {
+								$storage->upload([
+									'name' => $data['name'],
+									'tmp_name' => $storage->getDirPath($data['name']),
+								]);
+							}
 
 							if($storage->file_exists($data['name'])) {
 								$metadata[$url] = $storage->getUrlPath($data['name']);
@@ -897,23 +904,15 @@ class Media {
 	 * @param int $new_width Maximum width for the new image if zero will box to height
 	 * @param int $new_height Maximum height for the new image if zero will box to width
 	 */
-	public static function create_image($src_file, $new_file, StorageStrategy $storage, $new_width, $new_height): void {
+	public static function create_image($src_path, $new_path, $new_width, $new_height): void {
 		global $USE_IMAGE_MAGICK;
 
 		if($USE_IMAGE_MAGICK) {
-			self::create_image_imagick($src_file, $new_file, $storage, $new_width, $new_height);
+			self::create_image_imagick($src_path, $new_path, $new_width, $new_height);
 		} elseif(extension_loaded('gd') && function_exists('gd_info')) {
-			self::create_image_gd($src_file, $new_file, $storage, $new_width, $new_height);
+			self::create_image_gd($src_path, $new_path, $new_width, $new_height);
 		} else {
 			throw new Exception('No image handler for image conversions');
-		}
-
-		//If file doesn't according to the upload strategy then upload it to the correct place. This will only run if the media storage is remote to the server
-		if(!$storage->file_exists($new_file)) {
-			$storage->upload([
-				'name' => $new_file,
-				'tmp_name' => $storage->getDirPath($new_file),
-			]);
 		}
 	}
 
@@ -924,19 +923,15 @@ class Media {
 	 * Most portals using imagick have ImageMagick installed on server and make system calls in order to use it.
 	 * At the time of making this function no know portals have the imagick pecl package installed but and implemenation was made as we are potentially heading in that direction.
 	 *
-	 * @param string $src_file Filename to image base
-	 * @param string $new_file Filename for newly resized image
-	 * @param StorageStrategy $storage Class that instructs where how how an image should be stored
+	 * @param string $src_file Filepath to image base
+	 * @param string $new_file Filepath for newly resized image
 	 * @param int $new_width Maximum width for the new image if zero will box to height
 	 * @param int $new_height Maximum height for the new image if zero will box to width
 	 */
 	private static function create_image_imagick(
-		string $src_file, string $new_file,
-		StorageStrategy $storage,
+		string $src_path, string $new_path,
 		int $new_width, int $new_height
 	): void {
-		$src_path = $storage->getDirPath($src_file);
-		$new_path = $storage->getDirPath($new_file);
 
 		if($new_height === 0 && $new_width === 0) {
 			throw new Exception('Must have width or height as non zero values');
@@ -975,18 +970,13 @@ class Media {
 	 *
 	 * @param string $src_file Filename to image base
 	 * @param string $new_file Filename for newly resized image
-	 * @param StorageStrategy $storage Class that instructs where how how an image should be stored
 	 * @param int $new_width Maximum width for the new image if zero will box to height
 	 * @param int $new_height Maximum height for the new image if zero will box to width
 	 */
 	private static function create_image_gd(
-		string $src_file, string $new_file,
-		StorageStrategy $storage,
+		string $src_path, string $new_path,
 		int $new_width, int $new_height
 	): void {
-
-		$src_path = $storage->getDirPath($src_file);
-		$new_path = $storage->getDirPath($new_file);
 
 		if($new_width === 0 && $new_height === 0) {
 			throw new Exception('Must have width or height as non zero values');
@@ -999,7 +989,7 @@ class Media {
 		$mime_type = $size['mime'];
 
 		if(!self::enough_memory_gd($size[0], $size[1])) {
-			throw new MediaException(MediaException::NotEnoughMemoryImage, ': ' . $new_file);
+			throw new MediaException(MediaException::NotEnoughMemoryImage, ': ' . $new_path);
 		}
 
 		$orig_width = $width;

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -1167,24 +1167,16 @@ class Media {
 				QueryUtil::executeQuery($conn, $query, [$media_id]);
 			}
 
+			$storage = StorageFactory::make();
+
 			//Unlink all files
 			if($remove_files) {
 				$root_url = self::getMediaRootUrl();
 				$root_path = self::getMediaRootPath();
 				foreach($media_urls as $url) {
-					if($url && $root_url) {
-						if(strpos($url, $root_url) === 0){		//Only images residing on local server can be deleted
-							//Convert url to a local path
-							$path = $root_path . substr($url, strlen($root_url));
-							if(file_exists($path)){
-								if(is_writable($path)) {
-									if(!unlink($path)) {
-										error_log("WARNING: File (path: " . $path . ") failed to delete from server");
-									}
-								} else{
-									throw new MediaException(MediaException::FilepathNotWritable, $path);
-								}
-							}
+					if($url && $storage->file_exists($url)) {
+						if(!$storage->remove($url)) {
+							error_log("WARNING: File (path: " . $url . ") failed to delete from server");
 						}
 					}
 				}

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -603,13 +603,11 @@ class Media {
 
 					foreach($urls as $url => $data) {
 						if(!($media_metadata[$url] ?? false)) {
-							$temp_path = $GLOBALS['SERVER_ROOT'] . '/temp/' . $data['name'];
+							$temp_path = UploadUtil::getTempDir() . $data['name'];
 
-							// TODO (Logan) clean up temp files on failure
 							self::create_image(
 								$file['tmp_name'],
 								$temp_path,
-								// $storage->getDirPath($data['name']),
 								$data['width'],
 								$data['height']
 							);
@@ -628,6 +626,7 @@ class Media {
 								$createdFilepaths[$url] = $storage->getDirPath($data['name']);
 							}
 
+							unlink($temp_path);
 						}
 					}
 					$storage->upload($file);
@@ -653,9 +652,7 @@ class Media {
 			mysqli_rollback($conn);
 
 			foreach($createdFilepaths as $field => $filepath) {
-				if(file_exists($filepath)) {
-					unlink($filepath);
-				}
+				$storage->remove($filepath);
 			}
 
 			array_push(self::$errors, $th->getMessage());

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -607,6 +607,10 @@ class Media {
 						if(!($media_metadata[$url] ?? false)) {
 							$temp_path = UploadUtil::getTempDir() . $data['name'];
 
+							if(!is_writable($temp_path)) {
+								throw new MediaException(MediaException::FilepathNotWritable, $temp_path);
+							}
+
 							self::create_image(
 								$file['tmp_name'],
 								$temp_path,

--- a/classes/StorageStrategy.php
+++ b/classes/StorageStrategy.php
@@ -263,7 +263,7 @@ class S3Storage extends StorageStrategy {
 			'use_path_style_endpoint' => true,
 			'credentials' => [
 				'key' => $GLOBALS['S3_ACCESS_KEY_ID'],
-				'secret' => $GLOBALS['S3_SECRET_ID']
+				'secret' => $GLOBALS['S3_SECRET_ACCESS_KEY']
 			],
 		]);
 	}

--- a/classes/StorageStrategy.php
+++ b/classes/StorageStrategy.php
@@ -4,24 +4,32 @@ include_once($SERVER_ROOT . "/classes/MediaType.php");
 include_once($SERVER_ROOT . "/classes/utilities/UploadUtil.php");
 require_once($SERVER_ROOT . '/vendor/autoload.php');
 
+/**
+ * Class meant to abstract storage file operations when storing
+ * files that are not temporary.
+ *
+ * The concept of a $file array is just the same keys as create
+ * when php does a file upload for ease of integration.
+ * file paths are also supported.
+ */
 abstract class StorageStrategy {
 	/**
 	 * If a file is given then return the storage path for that resource otherwise just return the root path.
-	 * @param string | array $file {name: string, type: string, tmp_name: string, error: int, size: int}
+	 * @param string|array $file {name: string, type: string, tmp_name: string, error: int, size: int}
 	 * @return string
 	 */
 	abstract public function getDirPath($file): string;
 
 	/**
 	 * If a file is given then return the url path to that resource otherwise just return the root url path.
-	 * @param string | array $file {name: string, type: string, tmp_name: string, error: int, size: int}
+	 * @param string|array $file {name: string, type: string, tmp_name: string, error: int, size: int}
 	 * @return string
 	 */
 	abstract public function getUrlPath($file): string;
 
 	/**
 	 * Function to check if a file exists for the storage location of the upload strategy.
-	 * @param string | array $file {name: string, type: string, tmp_name: string, error: int, size: int}
+	 * @param string|array $file {name: string, type: string, tmp_name: string, error: int, size: int}
 	 * @return bool
 	 */
 	abstract public function file_exists($file): bool;
@@ -36,11 +44,11 @@ abstract class StorageStrategy {
 
 	/**
 	 * Function to handle how a file should be removed.
-	 * @param array $file {name: string, type: string, tmp_name: string, error: int, size: int}
+	 * @param string|array $file {name: string, type: string, tmp_name: string, error: int, size: int}
 	 * @return bool
 	 * @throws MediaException(MediaException::DuplicateMediaFile)
 	 */
-	abstract public function remove(string $file): bool;
+	abstract public function remove($file): bool;
 
 	/**
 	 * Function to handle renaming an existing file.
@@ -53,31 +61,39 @@ abstract class StorageStrategy {
 	abstract public function rename(string $filepath, string $new_filepath): void;
 }
 
+/**
+ * Local storage driver for StorageStrategy interface. Used for managing files
+ * stored on server's file system.
+ *
+ * This can be a risky strategy given how php works and to use this
+ * driver securely make sure to configure nginx or apache properly
+ */
 class LocalStorage extends StorageStrategy {
 	private string $path;
 
-	public function __construct($path = '') {
+	/**
+	 * @param String $path Path is string filepath starting with no slash and ending
+	 * with a slash. It serves as an extension of the root storage path to limit
+	 * where files can be stored.
+	 **/
+	public function __construct(string $path = '') {
 		$this->path = $path ?? '';
 	}
 
-	public function getDirPath($file = null): string {
-		$file_name = is_array($file)? $file['name']: $file;
+	public function getDirPath($file = ''): string {
+		$filename = is_array($file)? $file['name']: $file;
 		return $GLOBALS['MEDIA_ROOT_PATH'] .
 			(substr($GLOBALS['MEDIA_ROOT_PATH'],-1) != "/"? '/': '') .
-			$this->path . $file_name;
+			$this->path . $filename;
 	}
 
-	public function getUrlPath($file = null): string {
-		$file_name = is_array($file)? $file['name']: $file;
+	public function getUrlPath($file = ''): string {
+		$filename = is_array($file)? $file['name']: $file;
 		return $GLOBALS['MEDIA_ROOT_URL'] .
 		   	(substr($GLOBALS['MEDIA_ROOT_URL'],-1) != "/"? '/': '') .
-		   	$this->path . $file_name;
+			$this->path . $filename;
 	}
 
-	/**
-	 * Private help function for interal use that holds logic for how storage paths are created.
-	 * @return string
-	 */
 	public function file_exists($file): bool {
 		$filename = is_array($file)? $file['name']: $file;
 
@@ -90,12 +106,9 @@ class LocalStorage extends StorageStrategy {
 		return file_exists($this->getDirPath() . $filename);
 	}
 
-	/**
-	 * Upload implemenation stores files on the server and expect duplicate files to be handled by the caller
-	 */
 	public function upload(array $file): bool {
 		$dir_path = $this->getDirPath();
-		$file_path = $dir_path . $file['name'];
+		$filepath = $dir_path . $file['name'];
 
 		// Create Storage Directory If it doesn't exist
 		if(!is_dir($dir_path)) {
@@ -106,29 +119,37 @@ class LocalStorage extends StorageStrategy {
 			throw new MediaException(MediaException::FilepathNotWritable, $dir_path);
 		}
 
-		if(file_exists($file_path)) {
+		if(file_exists($filepath)) {
 			throw new MediaException(MediaException::DuplicateMediaFile);
 		}
 
 		//If Uploaded from $_POST then move file to new path
 		if(is_uploaded_file($file['tmp_name'])) {
-			move_uploaded_file($file['tmp_name'], $file_path);
-		//If temp path is on server then just move to new location;
+			move_uploaded_file($file['tmp_name'], $filepath);
+		//If temp path is on server then just move to new location
 		} else if(file_exists($file['tmp_name'])) {
-			rename($file['tmp_name'], $file_path);
+			rename($file['tmp_name'], $filepath);
 		//Otherwise assume tmp_name a url and stream file contents over
 		} else {
-			error_log("Moving" . $file['tmp_name'] . ' to ' . $file_path );
-			file_put_contents($file_path, fopen($file['tmp_name'], 'r'));
+			error_log("Moving" . $file['tmp_name'] . ' to ' . $filepath );
+			file_put_contents($filepath, fopen($file['tmp_name'], 'r'));
 		}
 
 		return true;
 	}
+
+
 	/**
-	 * @return bool
-	 * @param mixed $path
-	 */
-	static private function on_system($path) {
+	 * Checks if a given path leads to a file on system.
+	 *
+	 * Supports passing either the full absoulte path or the relative url path.
+	 * Relative url paths will get converted to absoulte paths.
+	 *
+	 * @access private
+	 * @param String $path Filepath that needs checking
+	 * @return Bool
+	 **/
+	static private function on_system(string $path): Bool {
 		//Check if path is absoulte path
 		if(file_exists($path)) {
 			return true;
@@ -143,7 +164,9 @@ class LocalStorage extends StorageStrategy {
 		return file_exists($dir_path);
 	}
 
-	public function remove(string $filename): bool {
+	public function remove($file): bool {
+		$filename = is_array($file)? $file['name']: $file;
+
 		if(!is_writable($GLOBALS['SERVER_ROOT'] . $filename)) {
 			throw new MediaException(MediaException::FilepathNotWritable, $filename);
 		}
@@ -202,10 +225,35 @@ class LocalStorage extends StorageStrategy {
 	}
 }
 
+/**
+ * S3 storage driver for StorageStrategy interface. Used for managing files
+ * storage in s3 object storage on same server or remote server.
+ *
+ * If possible this is the recomended driver to use because it is more secure
+ * by default.
+ *
+ * All technologies that support s3 client interface should work. However
+ * the follow are onces we aim to support.
+ * - CEPH
+ */
 class S3Storage extends StorageStrategy {
 	private $client;
 	private $path;
 
+	/**
+	 * Intializes s3 client and takes a path that will serve as the root s3 key path.
+	 * This value should be prepended to incoming files and/or filepaths.
+	 *
+	 * S3 Client is intialized using the following symbini.php config variables
+	 * $S3_REGION: region
+	 * $S3_ENDPOINT: endpoint
+	 * $S3_ACCESS_KEY_ID: credentials => key
+	 * $S3_SECRET_ID: credentials => secret
+	 *
+	 * @param String $path Path is string filepath starting with no slash and ending
+	 * with a slash. It serves as an extension of the root storage path to limit
+	 * where files can be stored.
+	 **/
 	public function __construct($path = '') {
 		$this->path = $path;
 		$this->client =  new Aws\S3\S3Client([
@@ -220,7 +268,7 @@ class S3Storage extends StorageStrategy {
 		]);
 	}
 
-	public function getDirPath($file = null): string {
+	public function getDirPath($file = ''): string {
 		$file_name = is_array($file)? $file['name']: $file;
 
 		return $GLOBALS['MEDIA_ROOT_URL'] .
@@ -228,7 +276,7 @@ class S3Storage extends StorageStrategy {
 			$this->path . $file_name;
 	}
 
-	public function getUrlPath($file = null): string {
+	public function getUrlPath($file = ''): string {
 		$file_name = is_array($file)? $file['name']: $file;
 		return $GLOBALS['MEDIA_DOMAIN'] . $GLOBALS['MEDIA_ROOT_URL'] .
 		   	(substr($GLOBALS['MEDIA_ROOT_URL'],-1) != "/"? '/': '') .
@@ -257,7 +305,14 @@ class S3Storage extends StorageStrategy {
 		return true;
 	}
 
-	function getPathFromUrl($url) {
+	/**
+	 * Takes url and normailzes to just the key path without the
+	 * Media Bucket Name.
+	 *
+	 * @param String $url s3 url either with s3:// url or only path url or filepath
+	 * @return Bool|String
+	 **/
+	function getPathFromUrl(String $url) {
 		$url_parts = UploadUtil::decomposeUrl($url);
 		$bucket_path = '/' . $GLOBALS['S3_MEDIA_BUCKET_NAME'];
 		$path = $url_parts['path'];
@@ -273,8 +328,8 @@ class S3Storage extends StorageStrategy {
 		return $path;
 	}
 
-	public function remove(string $filename): bool {
-
+	public function remove($file): bool {
+		$filename = is_array($file)? $file['name']: $file;
 		$trimed_file_name = str_replace($GLOBALS['MEDIA_DOMAIN'] . $GLOBALS['S3_MEDIA_BUCKET_NAME'],'', $filename);
 
 		$result = $this->client->deleteObject([
@@ -289,7 +344,7 @@ class S3Storage extends StorageStrategy {
 		return false;
 	}
 
-	public function rename(string $filepath, string $new_filepath): void {
+	public function rename(String $filepath, String $new_filepath): Void {
 		$src_path = self::getPathFromUrl($filepath);
 		$result = $this->client->copyObject([
 			'Bucket' => $GLOBALS['S3_MEDIA_BUCKET_NAME'],
@@ -302,7 +357,20 @@ class S3Storage extends StorageStrategy {
 }
 
 class StorageFactory {
-	static function make($path = ''): StorageStrategy {
+	/**
+	 * Static Factory for creating correct storage driver based
+	 * on symbini config.
+	 *
+	 * Requires $STORAGE_DRIVER be set in the config/symbini.php
+	 * to either 'local' or 's3'.
+	 *
+	 * @param String $path Path is string filepath starting with no slash and ending
+	 * with a slash. It serves as an extension of the root storage path to limit
+	 * where files can be stored.
+	 * @return StorageStrategy
+	 * @throws Exception if $STORAGE_DRIVER is not 'local' or 's3'
+	 **/
+	static function make(String $path = ''): StorageStrategy {
 		switch($GLOBALS['STORAGE_DRIVER']) {
 			case 'local': return new LocalStorage($path);
 			case 's3': return new S3Storage($path);

--- a/classes/StorageStrategy.php
+++ b/classes/StorageStrategy.php
@@ -370,10 +370,13 @@ class StorageFactory {
 	 * @return StorageStrategy
 	 * @throws Exception if $STORAGE_DRIVER is not 'local' or 's3'
 	 **/
-	static function make(String $path = ''): StorageStrategy {
-		switch($GLOBALS['STORAGE_DRIVER'] ?? 'local') {
-			case 'local': return new LocalStorage($path);
-			case 's3':
+	const LOCAL_STORAGE = 'local';
+	const S3_STORAGE = 's3';
+
+	static function make(String $path = '', ?String $driverOverride = null): StorageStrategy {
+		switch($driverOverride ?? $GLOBALS['STORAGE_DRIVER'] ?? self::LOCAL_STORAGE) {
+			case self::LOCAL_STORAGE: return new LocalStorage($path);
+			case self::S3_STORAGE:
 				if(class_exists('Aws\S3\S3Client')) {
 					return new S3Storage($path);
 				} else {

--- a/classes/StorageStrategy.php
+++ b/classes/StorageStrategy.php
@@ -349,7 +349,7 @@ class S3Storage extends StorageStrategy {
 	 * @param String $url s3 url either with s3:// url or only path url or filepath
 	 * @return Bool|String
 	 **/
-	function getPathFromUrl(String $url) {
+	private function getPathFromUrl(String $url) {
 		$url_parts = UploadUtil::decomposeUrl($url);
 		$bucket_path = '/' . $GLOBALS['S3_MEDIA_BUCKET_NAME'];
 		$path = $url_parts['path'];

--- a/classes/StorageStrategy.php
+++ b/classes/StorageStrategy.php
@@ -1,6 +1,7 @@
 <?php
 include_once($SERVER_ROOT . "/classes/MediaException.php");
 include_once($SERVER_ROOT . "/classes/MediaType.php");
+require_once($SERVER_ROOT . '/vendor/autoload.php');
 
 abstract class StorageStrategy {
 	/**
@@ -195,4 +196,49 @@ class LocalStorage extends StorageStrategy {
 			rename($dir_path . $filepath, $dir_path . $new_filepath);
 		}
 	}
+}
+
+class S3Storage extends StorageStrategy {
+	private $client;
+
+	public function __construct() {
+		$this->client =  new Aws\S3\S3Client([
+			'version' => 'latest',
+			'region'  => $GLOBALS['S3_REGION'],
+			'endpoint' => $GLOBALS['S3_ENDPOINT'],
+			'use_path_style_endpoint' => true,
+			'credentials' => [
+				'key' => $GLOBALS['S3_ACCESS_KEY_ID'],
+				'secret' => $GLOBALS['S3_SECRET_ID']
+			],
+		]);
+	}
+
+	public function getDirPath($file = null): string {
+		$file_name = is_array($file)? $file['name']: $file;
+		return $GLOBALS['MEDIA_ROOT_PATH'] .
+			(substr($GLOBALS['MEDIA_ROOT_PATH'],-1) != "/"? '/': '') .
+			$this->path . $file_name;
+	}
+
+	public function getUrlPath($file = null): string {
+		$file_name = is_array($file)? $file['name']: $file;
+		return $GLOBALS['MEDIA_ROOT_URL'] .
+		   	(substr($GLOBALS['MEDIA_ROOT_URL'],-1) != "/"? '/': '') .
+		   	$this->path . $file_name;
+	}
+
+	public function file_exists($file): bool {}
+
+	public function upload(array $file): bool {
+		// TODO (Logan) modular bucket name?
+		$this->client->putObject([
+			'Bucket' => $GLOBALS['S3_MEDIA_BUCKET_NAME'],
+			'Key'    => $file['name'],
+			'Body'   => fopen($file['tmp_name']),
+		]);
+	}
+
+	public function remove(string $filename): bool {}
+	public function rename(string $filepath, string $new_filepath): void {}
 }

--- a/classes/StorageStrategy.php
+++ b/classes/StorageStrategy.php
@@ -15,50 +15,50 @@ require_once($SERVER_ROOT . '/vendor/autoload.php');
 abstract class StorageStrategy {
 	/**
 	 * If a file is given then return the storage path for that resource otherwise just return the root path.
-	 * @param string|array $file {name: string, type: string, tmp_name: string, error: int, size: int}
-	 * @return string
+	 * @param String|Array $file {name: String, type: String, tmp_name: String, error: Int, size: Int}
+	 * @return String
 	 */
-	abstract public function getDirPath($file): string;
+	abstract public function getDirPath($file): String;
 
 	/**
 	 * If a file is given then return the url path to that resource otherwise just return the root url path.
-	 * @param string|array $file {name: string, type: string, tmp_name: string, error: int, size: int}
-	 * @return string
+	 * @param String|Array $file {name: String, type: String, tmp_name: String, error: Int, size: Int}
+	 * @return String
 	 */
-	abstract public function getUrlPath($file): string;
+	abstract public function getUrlPath($file): String;
 
 	/**
 	 * Function to check if a file exists for the storage location of the upload strategy.
-	 * @param string|array $file {name: string, type: string, tmp_name: string, error: int, size: int}
-	 * @return bool
+	 * @param String|Array $file {name: String, type: String, tmp_name: String, error: Int, size: Int}
+	 * @return Bool
 	 */
-	abstract public function file_exists($file): bool;
+	abstract public function file_exists($file): Bool;
 
 	/**
 	 * Function to handle how a file should be uploaded.
-	 * @param array $file {name: string, type: string, tmp_name: string, error: int, size: int}
-	 * @return bool
+	 * @param Array $file {name: String, type: String, tmp_name: String, error: Int, size: Int}
+	 * @return Bool
 	 * @throws MediaException(MediaException::DuplicateMediaFile)
 	 */
-	abstract public function upload(array $file): bool;
+	abstract public function upload(Array $file): Bool;
 
 	/**
 	 * Function to handle how a file should be removed.
-	 * @param string|array $file {name: string, type: string, tmp_name: string, error: int, size: int}
-	 * @return bool
+	 * @param String|Array $file {name: String, type: String, tmp_name: String, error: Int, size: Int}
+	 * @return Bool
 	 * @throws MediaException(MediaException::DuplicateMediaFile)
 	 */
-	abstract public function remove($file): bool;
+	abstract public function remove($file): Bool;
 
 	/**
 	 * Function to handle renaming an existing file.
-	 * @param string $filepath
-	 * @param array $new_filepath
-	 * @return bool
+	 * @param String $filepath
+	 * @param Array $new_filepath
+	 * @return Bool
 	 * @throws MediaException(MediaException::FileDoesNotExist)
 	 * @throws MediaException(MediaException::FileAlreadyExists)
 	 */
-	abstract public function rename(string $filepath, string $new_filepath): void;
+	abstract public function rename(String $filepath, String $new_filepath): void;
 }
 
 /**
@@ -69,32 +69,32 @@ abstract class StorageStrategy {
  * driver securely make sure to configure nginx or apache properly
  */
 class LocalStorage extends StorageStrategy {
-	private string $path;
+	private String $path;
 
 	/**
-	 * @param String $path Path is string filepath starting with no slash and ending
+	 * @param String $path Path is String filepath starting with no slash and ending
 	 * with a slash. It serves as an extension of the root storage path to limit
 	 * where files can be stored.
 	 **/
-	public function __construct(string $path = '') {
+	public function __construct(String $path = '') {
 		$this->path = $path ?? '';
 	}
 
-	public function getDirPath($file = ''): string {
+	public function getDirPath($file = ''): String {
 		$filename = is_array($file)? $file['name']: $file;
 		return $GLOBALS['MEDIA_ROOT_PATH'] .
 			(substr($GLOBALS['MEDIA_ROOT_PATH'],-1) != "/"? '/': '') .
 			$this->path . $filename;
 	}
 
-	public function getUrlPath($file = ''): string {
+	public function getUrlPath($file = ''): String {
 		$filename = is_array($file)? $file['name']: $file;
 		return $GLOBALS['MEDIA_ROOT_URL'] .
 		   	(substr($GLOBALS['MEDIA_ROOT_URL'],-1) != "/"? '/': '') .
 			$this->path . $filename;
 	}
 
-	public function file_exists($file): bool {
+	public function file_exists($file): Bool {
 		$filename = is_array($file)? $file['name']: $file;
 
 		if($filename === null) return false;
@@ -106,7 +106,7 @@ class LocalStorage extends StorageStrategy {
 		return file_exists($this->getDirPath() . $filename);
 	}
 
-	public function upload(array $file): bool {
+	public function upload(array $file): Bool {
 		$dir_path = $this->getDirPath();
 		$filepath = $dir_path . $file['name'];
 
@@ -149,7 +149,7 @@ class LocalStorage extends StorageStrategy {
 	 * @param String $path Filepath that needs checking
 	 * @return Bool
 	 **/
-	static private function on_system(string $path): Bool {
+	static private function on_system(String $path): Bool {
 		//Check if path is absoulte path
 		if(file_exists($path)) {
 			return true;
@@ -164,7 +164,7 @@ class LocalStorage extends StorageStrategy {
 		return file_exists($dir_path);
 	}
 
-	public function remove($file): bool {
+	public function remove($file): Bool {
 		$filename = is_array($file)? $file['name']: $file;
 
 		if(!is_writable($GLOBALS['SERVER_ROOT'] . $filename)) {
@@ -199,7 +199,7 @@ class LocalStorage extends StorageStrategy {
 		return false;
 	}
 
-	public function rename(string $filepath, string $new_filepath): void {
+	public function rename(String $filepath, String $new_filepath): void {
 		//Remove MEDIA_ROOT_PATH + Path from filepath if it exists
 		global $SERVER_ROOT;
 
@@ -250,7 +250,7 @@ class S3Storage extends StorageStrategy {
 	 * $S3_ACCESS_KEY_ID: credentials => key
 	 * $S3_SECRET_ID: credentials => secret
 	 *
-	 * @param String $path Path is string filepath starting with no slash and ending
+	 * @param String $path Path is String filepath starting with no slash and ending
 	 * with a slash. It serves as an extension of the root storage path to limit
 	 * where files can be stored.
 	 **/
@@ -268,7 +268,7 @@ class S3Storage extends StorageStrategy {
 		]);
 	}
 
-	public function getDirPath($file = ''): string {
+	public function getDirPath($file = ''): String {
 		$file_name = is_array($file)? $file['name']: $file;
 
 		return $GLOBALS['MEDIA_ROOT_URL'] .
@@ -276,20 +276,20 @@ class S3Storage extends StorageStrategy {
 			$this->path . $file_name;
 	}
 
-	public function getUrlPath($file = ''): string {
+	public function getUrlPath($file = ''): String {
 		$file_name = is_array($file)? $file['name']: $file;
 		return $GLOBALS['MEDIA_DOMAIN'] . $GLOBALS['MEDIA_ROOT_URL'] .
 		   	(substr($GLOBALS['MEDIA_ROOT_URL'],-1) != "/"? '/': '') .
 		   	$this->path . $file_name;
 	}
 
-	public function file_exists($file): bool {
+	public function file_exists($file): Bool {
 		$filename = is_array($file)? $file['name']: $file;
 
 		return $this->client->doesObjectExistV2($GLOBALS['S3_MEDIA_BUCKET_NAME'], self::getPathFromUrl($filename));
 	}
 
-	public function upload(array $file): bool {
+	public function upload(array $file): Bool {
 		if(!file_exists($file['tmp_name'])) {
 			throw new MediaException(MediaException::FileDoesNotExist, $file['tmp_name']);
 		}
@@ -328,7 +328,7 @@ class S3Storage extends StorageStrategy {
 		return $path;
 	}
 
-	public function remove($file): bool {
+	public function remove($file): Bool {
 		$filename = is_array($file)? $file['name']: $file;
 		$trimed_file_name = str_replace($GLOBALS['MEDIA_DOMAIN'] . $GLOBALS['S3_MEDIA_BUCKET_NAME'],'', $filename);
 
@@ -364,7 +364,7 @@ class StorageFactory {
 	 * Requires $STORAGE_DRIVER be set in the config/symbini.php
 	 * to either 'local' or 's3'.
 	 *
-	 * @param String $path Path is string filepath starting with no slash and ending
+	 * @param String $path Path is String filepath starting with no slash and ending
 	 * with a slash. It serves as an extension of the root storage path to limit
 	 * where files can be stored.
 	 * @return StorageStrategy

--- a/classes/StorageStrategy.php
+++ b/classes/StorageStrategy.php
@@ -1,6 +1,7 @@
 <?php global $SERVER_ROOT;
 include_once($SERVER_ROOT . "/classes/MediaException.php");
 include_once($SERVER_ROOT . "/classes/MediaType.php");
+include_once($SERVER_ROOT . "/classes/utilities/UploadUtil.php");
 require_once($SERVER_ROOT . '/vendor/autoload.php');
 
 abstract class StorageStrategy {
@@ -77,7 +78,6 @@ class LocalStorage extends StorageStrategy {
 	 * Private help function for interal use that holds logic for how storage paths are created.
 	 * @return string
 	 */
-
 	public function file_exists($file): bool {
 		$filename = is_array($file)? $file['name']: $file;
 
@@ -144,6 +144,10 @@ class LocalStorage extends StorageStrategy {
 	}
 
 	public function remove(string $filename): bool {
+		if(!is_writable($GLOBALS['SERVER_ROOT'] . $filename)) {
+			throw new MediaException(MediaException::FilepathNotWritable, $filename);
+		}
+
 		//Check Relative Path
 		if($this->file_exists($filename)) {
 			if(!unlink($this->getDirPath($filename))) {
@@ -202,7 +206,7 @@ class S3Storage extends StorageStrategy {
 	private $client;
 	private $path;
 
-	public function __construct($path) {
+	public function __construct($path = '') {
 		$this->path = $path;
 		$this->client =  new Aws\S3\S3Client([
 			'version' => 'latest',
@@ -232,7 +236,9 @@ class S3Storage extends StorageStrategy {
 	}
 
 	public function file_exists($file): bool {
-		return $this->client->doesObjectExistV2($GLOBALS['S3_MEDIA_BUCKET_NAME'], self::getDirPath($file));
+		$filename = is_array($file)? $file['name']: $file;
+
+		return $this->client->doesObjectExistV2($GLOBALS['S3_MEDIA_BUCKET_NAME'], self::getPathFromUrl($filename));
 	}
 
 	public function upload(array $file): bool {
@@ -251,10 +257,41 @@ class S3Storage extends StorageStrategy {
 		return true;
 	}
 
+	function getPathFromUrl($url) {
+		$url_parts = UploadUtil::decomposeUrl($url);
+		$bucket_path = '/' . $GLOBALS['S3_MEDIA_BUCKET_NAME'];
+		$path = $url_parts['path'];
+
+		if($path === $url_parts['basename']) {
+			$path = self::getDirPath($path);
+		}
+
+		if(strpos($path, $bucket_path) === 0) {
+			return substr($path, strlen($bucket_path));
+		}
+
+		return $path;
+	}
+
 	public function remove(string $filename): bool {
+
+		$trimed_file_name = str_replace($GLOBALS['MEDIA_DOMAIN'] . $GLOBALS['S3_MEDIA_BUCKET_NAME'],'', $filename);
+
+		$result = $this->client->deleteObject([
+			'Bucket' => $GLOBALS['S3_MEDIA_BUCKET_NAME'],
+			'Key'    => self::getPathFromUrl($filename),
+		]);
+
+		if(($metadata = $result->get('@metadata')) && ($metadata['statusCode'] ?? false) === 204) {
+			return true;
+		}
+
 		return false;
 	}
-	public function rename(string $filepath, string $new_filepath): void {}
+
+	public function rename(string $filepath, string $new_filepath): void {
+		// TODO (Logan)
+	}
 }
 
 class StorageFactory {

--- a/classes/StorageStrategy.php
+++ b/classes/StorageStrategy.php
@@ -287,17 +287,31 @@ class S3Storage extends StorageStrategy {
 	}
 
 	public function upload(array $file): Bool {
+		$tempPath = null;
 		if(!file_exists($file['tmp_name'])) {
-			throw new MediaException(MediaException::FileDoesNotExist, $file['tmp_name']);
+			$parts = UploadUtil::decomposeUrl($file['tmp_name']);
+
+			// If there is a scheme either http or https then download file for s3 upload
+			if($parts['scheme'] ?? false) {
+				$tempPath = UploadUtil::getTempDir() . $this->path . $file['name'];
+				file_put_contents($tempPath, fopen($file['tmp_name'], 'r'));
+			} else {
+				throw new MediaException(MediaException::FileDoesNotExist, $file['tmp_name']);
+			}
 		}
 
-		$this->client->putObject([
-			'Bucket' => $GLOBALS['S3_MEDIA_BUCKET_NAME'],
-			'Key'    => $GLOBALS['MEDIA_ROOT_URL'] . (substr($GLOBALS['MEDIA_ROOT_URL'],-1) != "/"? '/': '') . $this->path . $file['name'],
-			'ContentType' => $file['type'],
-			'Body'   => fopen($file['tmp_name'], "r"),
-			'ACL' => 'public-read'
-		]);
+		try {
+			$this->client->putObject([
+				'Bucket' => $GLOBALS['S3_MEDIA_BUCKET_NAME'],
+				'Key'    => $GLOBALS['MEDIA_ROOT_URL'] . (substr($GLOBALS['MEDIA_ROOT_URL'],-1) != "/"? '/': '') . $this->path . $file['name'],
+				'ContentType' => $file['type'],
+				'Body'   => fopen($tempPath ?? $file['tmp_name'], "r"),
+				'ACL' => 'public-read'
+			]);
+
+		} finally {
+			if($tempPath) unlink($tempPath);
+		}
 
 		return true;
 	}

--- a/classes/StorageStrategy.php
+++ b/classes/StorageStrategy.php
@@ -238,8 +238,26 @@ class LocalStorage extends StorageStrategy {
  * If possible this is the recomended driver to use because it is more secure
  * by default.
  *
+ * Note this class should only rely on the following symbini vars:
+ * $S3_REGION: region
+ * $S3_PUBLIC_ENDPOINT: This endpoint is shown publicly in asset urls.
+ * $S3_ENDPOINT: This endpoint used for connecting to the s3 instance and will often be the same as the public one. There are some edge cases where this is not true.
+ * $S3_ACCESS_KEY_ID: credentials => key
+ * $S3_SECRET_ID: credentials => secret
+ * $S3_MEDIA_PATH: '/your_media_path';
+ *
+ * Do not use these options within this class they are only used in the local storage strategy.
+ *
+ * $MEDIA_ROOT_URL
+ * $MEDIA_ROOT_PATH
+ * $MEDIA_DOMAIN
+ *
+ * The reasoning fore keeping this out is simply because they are used in other parts of the
+ * codebase that do not use this pattern so coupling them is going to lead to avoidable
+ * problems. In the future this may not be the case, if so feel free to re-evaluate
+ *
  * All technologies that support s3 client interface should work. However
- * the follow are onces we aim to support.
+ * the follow are ones we aim to support.
  * - CEPH
  */
 class S3Storage extends StorageStrategy {
@@ -277,15 +295,14 @@ class S3Storage extends StorageStrategy {
 	public function getDirPath($file = ''): String {
 		$file_name = is_array($file)? $file['name']: $file;
 
-		return $GLOBALS['MEDIA_ROOT_URL'] .
-			(substr($GLOBALS['MEDIA_ROOT_URL'],-1) != "/"? '/': '') .
+		return $GLOBALS['S3_MEDIA_PATH'] .
+			(substr($GLOBALS['S3_MEDIA_PATH'],-1) != "/"? '/': '') .
 			$this->path . $file_name;
 	}
 
 	public function getUrlPath($file = ''): String {
 		$file_name = is_array($file)? $file['name']: $file;
-		return $GLOBALS['MEDIA_DOMAIN'] . $GLOBALS['MEDIA_ROOT_URL'] .
-		   	(substr($GLOBALS['MEDIA_ROOT_URL'],-1) != "/"? '/': '') .
+		return $GLOBALS['S3_PUBLIC_ENDPOINT'] . '/' . $GLOBALS['S3_MEDIA_BUCKET_NAME'] . $GLOBALS['S3_MEDIA_PATH'] . (substr($GLOBALS['S3_MEDIA_PATH'],-1) != "/"? '/': '') .
 		   	$this->path . $file_name;
 	}
 
@@ -312,7 +329,7 @@ class S3Storage extends StorageStrategy {
 		try {
 			$this->client->putObject([
 				'Bucket' => $GLOBALS['S3_MEDIA_BUCKET_NAME'],
-				'Key'    => $GLOBALS['MEDIA_ROOT_URL'] . (substr($GLOBALS['MEDIA_ROOT_URL'],-1) != "/"? '/': '') . $this->path . $file['name'],
+				'Key'    => $GLOBALS['S3_MEDIA_PATH'] . (substr($GLOBALS['S3_MEDIA_PATH'],-1) != "/"? '/': '') . $this->path . $file['name'],
 				'ContentType' => $file['type'],
 				'Body'   => fopen($tempPath ?? $file['tmp_name'], "r"),
 				'ACL' => 'public-read'
@@ -350,7 +367,7 @@ class S3Storage extends StorageStrategy {
 
 	public function remove($file): Bool {
 		$filename = is_array($file)? $file['name']: $file;
-		$trimed_file_name = str_replace($GLOBALS['MEDIA_DOMAIN'] . $GLOBALS['S3_MEDIA_BUCKET_NAME'],'', $filename);
+		$trimed_file_name = str_replace($GLOBALS['S3_ENDPOINT'] . '/' . $GLOBALS['S3_MEDIA_BUCKET_NAME'],'', $filename);
 
 		$result = $this->client->deleteObject([
 			'Bucket' => $GLOBALS['S3_MEDIA_BUCKET_NAME'],
@@ -376,20 +393,20 @@ class S3Storage extends StorageStrategy {
 	}
 }
 
+/**
+ * Static Factory for creating correct storage driver based
+ * on symbini config.
+ *
+ * Requires $STORAGE_DRIVER be set in the config/symbini.php
+ * to either 'local' or 's3'.
+ *
+ * @param String $path Path is String filepath starting with no slash and ending
+ * with a slash. It serves as an extension of the root storage path to limit
+ * where files can be stored.
+ * @return StorageStrategy
+ * @throws Exception if $STORAGE_DRIVER is not 'local' or 's3'
+ **/
 class StorageFactory {
-	/**
-	 * Static Factory for creating correct storage driver based
-	 * on symbini config.
-	 *
-	 * Requires $STORAGE_DRIVER be set in the config/symbini.php
-	 * to either 'local' or 's3'.
-	 *
-	 * @param String $path Path is String filepath starting with no slash and ending
-	 * with a slash. It serves as an extension of the root storage path to limit
-	 * where files can be stored.
-	 * @return StorageStrategy
-	 * @throws Exception if $STORAGE_DRIVER is not 'local' or 's3'
-	 **/
 	const LOCAL_STORAGE = 'local';
 	const S3_STORAGE = 's3';
 

--- a/classes/StorageStrategy.php
+++ b/classes/StorageStrategy.php
@@ -80,8 +80,20 @@ class LocalStorage extends StorageStrategy {
 		$this->path = $path ?? '';
 	}
 
+	private function strip_media_path_info(string $filepath) {
+		if(str_contains($filepath, $GLOBALS['MEDIA_ROOT_PATH'])) {
+			$filepath = str_replace($GLOBALS['MEDIA_ROOT_URL'], '', $filepath);
+		} else if(str_contains($filepath, $GLOBALS['MEDIA_ROOT_URL'])) {
+			$filepath = str_replace($GLOBALS['MEDIA_ROOT_URL'], '', $filepath);
+		}
+
+		return $filepath;
+	}
+
 	public function getDirPath($file = ''): String {
 		$filename = is_array($file)? $file['name']: $file;
+		$filename = $this->strip_media_path_info($filename);
+
 		return $GLOBALS['MEDIA_ROOT_PATH'] .
 			(substr($GLOBALS['MEDIA_ROOT_PATH'],-1) != "/"? '/': '') .
 			$this->path . $filename;
@@ -89,6 +101,8 @@ class LocalStorage extends StorageStrategy {
 
 	public function getUrlPath($file = ''): String {
 		$filename = is_array($file)? $file['name']: $file;
+		$filename = $this->strip_media_path_info($filename);
+
 		return $GLOBALS['MEDIA_ROOT_URL'] .
 		   	(substr($GLOBALS['MEDIA_ROOT_URL'],-1) != "/"? '/': '') .
 			$this->path . $filename;
@@ -99,11 +113,7 @@ class LocalStorage extends StorageStrategy {
 
 		if($filename === null) return false;
 
-		if(str_contains($filename, $this->getUrlPath())) {
-			$filename = str_replace($this->getUrlPath(), '', $filename);
-		}
-
-		return file_exists($this->getDirPath() . $filename);
+		return file_exists($this->getDirPath($filename));
 	}
 
 	public function upload(array $file): Bool {
@@ -134,7 +144,6 @@ class LocalStorage extends StorageStrategy {
 
 		return true;
 	}
-
 
 	/**
 	 * Checks if a given path leads to a file on system.

--- a/classes/StorageStrategy.php
+++ b/classes/StorageStrategy.php
@@ -123,12 +123,9 @@ class LocalStorage extends StorageStrategy {
 			throw new MediaException(MediaException::DuplicateMediaFile);
 		}
 
-		//If Uploaded from $_POST then move file to new path
-		if(is_uploaded_file($file['tmp_name'])) {
-			move_uploaded_file($file['tmp_name'], $filepath);
-		//If temp path is on server then just move to new location
-		} else if(file_exists($file['tmp_name'])) {
-			rename($file['tmp_name'], $filepath);
+		//If temp path is on server then copy to new location
+		if(file_exists($file['tmp_name'])) {
+			copy($file['tmp_name'], $filepath);
 		//Otherwise assume tmp_name a url and stream file contents over
 		} else {
 			error_log("Moving" . $file['tmp_name'] . ' to ' . $filepath );

--- a/classes/StorageStrategy.php
+++ b/classes/StorageStrategy.php
@@ -371,9 +371,14 @@ class StorageFactory {
 	 * @throws Exception if $STORAGE_DRIVER is not 'local' or 's3'
 	 **/
 	static function make(String $path = ''): StorageStrategy {
-		switch($GLOBALS['STORAGE_DRIVER']) {
+		switch($GLOBALS['STORAGE_DRIVER'] ?? 'local') {
 			case 'local': return new LocalStorage($path);
-			case 's3': return new S3Storage($path);
+			case 's3':
+				if(class_exists('Aws\S3\S3Client')) {
+					return new S3Storage($path);
+				} else {
+					throw new Exception('S3 STORAGE_DRIVER requires Aws\S3\S3Client to to be installed');
+				}
 			default: throw new Exception('STORAGE_DRIVER not configure properly. Use "local" or "s3" as options');
 		}
 

--- a/classes/StorageStrategy.php
+++ b/classes/StorageStrategy.php
@@ -1,4 +1,4 @@
-<?php
+<?php global $SERVER_ROOT;
 include_once($SERVER_ROOT . "/classes/MediaException.php");
 include_once($SERVER_ROOT . "/classes/MediaType.php");
 require_once($SERVER_ROOT . '/vendor/autoload.php');
@@ -241,4 +241,15 @@ class S3Storage extends StorageStrategy {
 
 	public function remove(string $filename): bool {}
 	public function rename(string $filepath, string $new_filepath): void {}
+}
+
+class StorageFactory {
+	static function make($path = ''): StorageStrategy {
+		switch($GLOBALS['STORAGE_DRIVER']) {
+			case 'local': return new LocalStorage($path);
+			case 's3': return new S3Storage($path);
+			default: throw new Exception('STORAGE_DRIVER not configure properly. Use "local" or "s3" as options');
+		}
+
+	}
 }

--- a/classes/StorageStrategy.php
+++ b/classes/StorageStrategy.php
@@ -200,8 +200,10 @@ class LocalStorage extends StorageStrategy {
 
 class S3Storage extends StorageStrategy {
 	private $client;
+	private $path;
 
-	public function __construct() {
+	public function __construct($path) {
+		$this->path = $path;
 		$this->client =  new Aws\S3\S3Client([
 			'version' => 'latest',
 			'region'  => $GLOBALS['S3_REGION'],
@@ -216,30 +218,42 @@ class S3Storage extends StorageStrategy {
 
 	public function getDirPath($file = null): string {
 		$file_name = is_array($file)? $file['name']: $file;
-		return $GLOBALS['MEDIA_ROOT_PATH'] .
-			(substr($GLOBALS['MEDIA_ROOT_PATH'],-1) != "/"? '/': '') .
+
+		return $GLOBALS['MEDIA_ROOT_URL'] .
+			(substr($GLOBALS['MEDIA_ROOT_URL'],-1) != "/"? '/': '') .
 			$this->path . $file_name;
 	}
 
 	public function getUrlPath($file = null): string {
 		$file_name = is_array($file)? $file['name']: $file;
-		return $GLOBALS['MEDIA_ROOT_URL'] .
+		return $GLOBALS['MEDIA_DOMAIN'] . $GLOBALS['MEDIA_ROOT_URL'] .
 		   	(substr($GLOBALS['MEDIA_ROOT_URL'],-1) != "/"? '/': '') .
 		   	$this->path . $file_name;
 	}
 
-	public function file_exists($file): bool {}
-
-	public function upload(array $file): bool {
-		// TODO (Logan) modular bucket name?
-		$this->client->putObject([
-			'Bucket' => $GLOBALS['S3_MEDIA_BUCKET_NAME'],
-			'Key'    => $file['name'],
-			'Body'   => fopen($file['tmp_name']),
-		]);
+	public function file_exists($file): bool {
+		return $this->client->doesObjectExistV2($GLOBALS['S3_MEDIA_BUCKET_NAME'], self::getDirPath($file));
 	}
 
-	public function remove(string $filename): bool {}
+	public function upload(array $file): bool {
+		if(!file_exists($file['tmp_name'])) {
+			throw new MediaException(MediaException::FileDoesNotExist, $file['tmp_name']);
+		}
+
+		$this->client->putObject([
+			'Bucket' => $GLOBALS['S3_MEDIA_BUCKET_NAME'],
+			'Key'    => $GLOBALS['MEDIA_ROOT_URL'] . (substr($GLOBALS['MEDIA_ROOT_URL'],-1) != "/"? '/': '') . $this->path . $file['name'],
+			'ContentType' => $file['type'],
+			'Body'   => fopen($file['tmp_name'], "r"),
+			'ACL' => 'public-read'
+		]);
+
+		return true;
+	}
+
+	public function remove(string $filename): bool {
+		return false;
+	}
 	public function rename(string $filepath, string $new_filepath): void {}
 }
 

--- a/classes/StorageStrategy.php
+++ b/classes/StorageStrategy.php
@@ -290,7 +290,14 @@ class S3Storage extends StorageStrategy {
 	}
 
 	public function rename(string $filepath, string $new_filepath): void {
-		// TODO (Logan)
+		$src_path = self::getPathFromUrl($filepath);
+		$result = $this->client->copyObject([
+			'Bucket' => $GLOBALS['S3_MEDIA_BUCKET_NAME'],
+			'CopySource' => $GLOBALS['S3_MEDIA_BUCKET_NAME'] . $src_path,
+			'Key' => self::getPathFromUrl($new_filepath)
+		]);
+
+		$this->remove($filepath);
 	}
 }
 

--- a/collections/editor/imageoccursubmit.php
+++ b/collections/editor/imageoccursubmit.php
@@ -45,7 +45,7 @@ if($isEditor){
 				Media::uploadAndInsert(
 					$_POST,
 					$_FILES['imgfile'],
-					new LocalStorage($path)
+					StorageFactory::make($path)
 				);
 
 				if($errors = Media::getErrors()) {

--- a/collections/editor/observationsubmit.php
+++ b/collections/editor/observationsubmit.php
@@ -60,7 +60,7 @@ if($collMap){
 						'occid' => $occid
 					],
 					$file, 
-					new LocalStorage($path)
+					StorageFactory::make($path)
 				);
 
 				if($errors = Media::getErrors()) {

--- a/collections/editor/occurrenceeditor.php
+++ b/collections/editor/occurrenceeditor.php
@@ -251,7 +251,7 @@ if($SYMB_UID){
 				}
 			}
 			elseif($action == 'Submit Image Edits'){
-				Media::update($_POST['imgid'], $_POST, new LocalStorage());
+				Media::update($_POST['imgid'], $_POST, StorageFactory::make());
 
 				if($errors = Media::getErrors()) {
 					$statusStr = 'ERROR: ' . array_pop($errors);
@@ -277,7 +277,7 @@ if($SYMB_UID){
 					Media::uploadAndInsert(
 						$_POST,
 						$_FILES['imgfile'],
-						new LocalStorage($path)
+						StorageFactory::make($path)
 					);
 
 					if($errors = Media::getErrors()) {
@@ -330,8 +330,8 @@ if($SYMB_UID){
 					Media::remap(
 						intval($_POST['imgid']),
 						$target_occid,
-						new LocalStorage($current_path),
-						new LocalStorage($remap_path)
+						StorageFactory::make($path),
+						StorageFactory::make($remap_path)
 					);
 
 					$statusStr = $LANG['IMAGE_REMAP_SUCCESS'] .' <a href="occurrenceeditor.php?occid=' . htmlspecialchars($target_occid, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '" target="_blank">' . htmlspecialchars($target_occid, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '</a>';

--- a/collections/editor/occurrenceeditor.php
+++ b/collections/editor/occurrenceeditor.php
@@ -330,7 +330,7 @@ if($SYMB_UID){
 					Media::remap(
 						intval($_POST['imgid']),
 						$target_occid,
-						StorageFactory::make($path),
+						StorageFactory::make($current_path),
 						StorageFactory::make($remap_path)
 					);
 

--- a/config/symbini_template.php
+++ b/config/symbini_template.php
@@ -43,7 +43,8 @@ $S3_MEDIA_BUCKET_NAME = '';
 $S3_REGION = '';
 $S3_ENDPOINT = '';
 $S3_ACCESS_KEY_ID = '';
-$S3_SECRET_ID = '';
+$S3_SECRET_ACCESS_KEY = '';
+
 
 //Pixel width of web images
 $IMG_WEB_WIDTH = 1400;

--- a/config/symbini_template.php
+++ b/config/symbini_template.php
@@ -35,7 +35,15 @@ $PUBLIC_MEDIA_UPLOAD_ROOT = '/content/imglib';
 $MEDIA_DOMAIN = '';				//Domain path to images, if different from portal
 $MEDIA_ROOT_URL = '';			//URL path to images
 $MEDIA_ROOT_PATH = '';			//Writable path to images, especially needed for downloading images
+
 $STORAGE_DRIVER = 'local'; // Can be either 'local' or 's3'. s3 option requires 'Aws\S3\S3Client' composer lib installed
+
+// Variables for s3 storage
+$S3_MEDIA_BUCKET_NAME = '';
+$S3_REGION = '';
+$S3_ENDPOINT = '';
+$S3_ACCESS_KEY_ID = '';
+$S3_SECRET_ID = '';
 
 //Pixel width of web images
 $IMG_WEB_WIDTH = 1400;

--- a/config/symbini_template.php
+++ b/config/symbini_template.php
@@ -39,12 +39,13 @@ $MEDIA_ROOT_PATH = '';			//Writable path to images, especially needed for downlo
 $STORAGE_DRIVER = 'local'; // Can be either 'local' or 's3'. s3 option requires 'Aws\S3\S3Client' composer lib installed
 
 // Variables for s3 storage
-$S3_MEDIA_BUCKET_NAME = '';
+$S3_MEDIA_BUCKET_NAME = ''; // Note if you are migrating to s3 from local then the bucket name should be the first part in your path.
 $S3_REGION = '';
-$S3_ENDPOINT = '';
-$S3_ACCESS_KEY_ID = '';
-$S3_SECRET_ACCESS_KEY = '';
-
+$S3_PUBLIC_ENDPOINT = ''; // Endpoint for showing assets to public. This could differ from the s3 endpoint depending on how things are setup.
+$S3_ENDPOINT = ''; // Endpoint to the s3 instance. This is seperated from the public access end point as it may be an internal ip or apart of container network.
+$S3_ACCESS_KEY_ID = ''; // S3 Credential ID
+$S3_SECRET_ACCESS_KEY = ''; // S3 Credential Password
+$S3_MEDIA_PATH = ''; // This can be blank. If you are supporting multiple portals with one s3 instance Recommendation is to split them into seperate buckets instead of at the path level in order to isolate the systems.
 
 //Pixel width of web images
 $IMG_WEB_WIDTH = 1400;

--- a/config/symbini_template.php
+++ b/config/symbini_template.php
@@ -35,7 +35,7 @@ $PUBLIC_MEDIA_UPLOAD_ROOT = '/content/imglib';
 $MEDIA_DOMAIN = '';				//Domain path to images, if different from portal
 $MEDIA_ROOT_URL = '';			//URL path to images
 $MEDIA_ROOT_PATH = '';			//Writable path to images, especially needed for downloading images
-
+$STORAGE_DRIVER = 'local'; // Can be either 'local' or 's3'. s3 option requires 'Aws\S3\S3Client' composer lib installed
 
 //Pixel width of web images
 $IMG_WEB_WIDTH = 1400;

--- a/imagelib/imgdetails.php
+++ b/imagelib/imgdetails.php
@@ -24,10 +24,10 @@ $status = '';
 
 if ($isEditor) {
 	if ($action == 'Submit Image Edits') {
-		Media::update($mediaID, $_POST, new LocalStorage());
+		Media::update($mediaID, $_POST, StorageFactory::make());
 	} elseif ($action == 'Transfer Image') {
 		if($targettid = $_REQUEST['targettid'] ?? false) {
-			Media::update($mediaID, ['tid' => $targettid ], new LocalStorage());
+			Media::update($mediaID, ['tid' => $targettid ], StorageFactory::make());
 
 			if($errors = Media::getErrors()) {
 				$status = 'Errors:<br/>' . implode('<br/>', $errors);

--- a/taxa/profile/tpeditor.php
+++ b/taxa/profile/tpeditor.php
@@ -122,7 +122,7 @@ if($isEditor && $action){
 			Media::uploadAndInsert(
 				$_POST,
 				$_FILES['imgfile'] ?? null,
-				new LocalStorage($path)
+				StorageFactory::make($path)
 			);
 		} catch(Exception $e) {
 			$statusStr .= '<br/>' . $e->getMessage();


### PR DESCRIPTION
# Issue

# Summary
Adds ability to choose between the follow storage drivers `local` or `s3`. Local will keep the behavior the same as it has always been and s3 will use an s3 instance or an compatible s3 alternative. I did most of the testing with minIO and testing still needs to be done on ceph.

## Config
Add the following `symbini.php`  vars to toggle this behavior from s3 and local file storage
```php
$STORAGE_DRIVER = 's3'
// or
$STORAGE_DRIVER = 'local'
```
If s3 is used then the following are needed
```php
$S3_ACCESS_KEY_ID="[ACCESS_KEY]";
$S3_SECRET_ID="[SECRET_KEY]";
$S3_REGION="[S3_REGION]"; // required but not sure if this does anything for local s3 alternatives
$S3_ENDPOINT="[URL_ENDPOINT]";
$S3_MEDIA_BUCKET_NAME = "[BUCKET_NAME]";
```

## Vendor Files
Added official s3 client with need to check if this will cause issues with 7.3, 8.0, 8.1.
Huge files added is from vendor files. Might be worth re discussing the removal of the vendor files from the repository and instead replacing it with builds for folks you don't want to use composer.

## Changes base on Suggestions
- The storage strategies now use the `StorageFactory` to make instances of `StorageStrategy` depending on the config.
- create_image function now takes just two paths instead of a storage strategy and stores files in a temporary local prior to being moved to either s3 or local storage.
- The base image file is now uploaded last so the local file system can create the image derivatives prior to the move. This needed because with s3 support base file would be moved off system and could not be used to support derivative creation.

## Testing
- [x] Make sure normal local storage driver is working as intended
- [ ] Check S3 driver is working for CEPH

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
