### PR TITLE
Add early return from failed imagecreatefromjpeg

### DIFF
--- a/classes/SpecProcessorOcr.php
+++ b/classes/SpecProcessorOcr.php
@@ -550,7 +550,7 @@ class SpecProcessorOcr extends Manager{
 						//$status = imagejpeg($dest,str_replace('_img.jpg','_crop.jpg',$this->imgUrlLocal));
 						$status = imagejpeg($dest,$this->imgUrlLocal);
 					}
-					imagedestroy($dest);
+					if($dest)imagedestroy($dest);
 					imagedestroy($img);
 				}
 			}
@@ -649,10 +649,11 @@ class SpecProcessorOcr extends Manager{
 			if(imagecopy($dest, $img, 0, 0, $bLeft, $bTop, $w, $h)){
 				$status = imagejpeg($dest,$this->imgUrlLocal);
 			}
-			imagedestroy($dest);
+			if($dest) imagedestroy($dest);
 			imagedestroy($img);
 			return true;
 		}
+		if($img) imagedestroy($img);
 		return false;
 	}
 

--- a/classes/SpecProcessorOcr.php
+++ b/classes/SpecProcessorOcr.php
@@ -563,9 +563,12 @@ class SpecProcessorOcr extends Manager{
 
 	private function imageTrimBorder($c=0,$t=100){
 		$img = imagecreatefromjpeg($this->imgUrlLocal);
+		if(!$img){
+			return false;
+		}
 		if (!is_numeric($c) || $c < 0 || $c > 255) {
 			// Color ($c) not valid, thus grab the color from the top left corner and use that as default
-			$rgb = imagecolorat($im, 2, 2); // 2 pixels in to avoid messy edges
+			$rgb = imagecolorat($img, 2, 2); // 2 pixels in to avoid messy edges
 			$r = ($rgb >> 16) & 0xFF;
 			$g = ($rgb >> 8) & 0xFF;
 			$b = $rgb & 0xFF;


### PR DESCRIPTION
# Description

Closes #2993 I think. Adds early return to failed imagecreatefromjpeg in imageTrimBorder. Also fixes a bug where $im is used instead of $img.

# Note

It's being recommended that we run `imagedestroy` in a few places in classes/SpecProcessorOcr.php. E.g., before the return statement in `imageTrimBorder` (~ln. 656) even in the case where `if($w < $width || $h < $height){` is not satisfied. @MuchQuak would this make sense to do as clean up?

And fix typo

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
    - #2993 
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
