### PR TITLE
MySQL compat: pass SRID argument to ST_GeomFromGeoJSON

### DIFF
--- a/classes/ChecklistVoucherAdmin.php
+++ b/classes/ChecklistVoucherAdmin.php
@@ -267,7 +267,7 @@ class ChecklistVoucherAdmin extends Manager {
 		}
 		if(isset($this->queryVariablesArr['includewkt']) && $this->queryVariablesArr['includewkt'] && $this->footprintGeoJson){
 			//Searh based on polygon
-			$sqlFrag .= "AND (ST_Within(p.lngLatPoint,ST_GeomFromGeoJson('" . $this->footprintGeoJson . "'))) ";
+			$sqlFrag .= "AND (ST_Within(p.lngLatPoint,ST_GeomFromGeoJson('" . $this->footprintGeoJson . "', 1, 0))) ";
 			$llStr = false;
 		}
 		if(isset($this->queryVariablesArr['latlngor']) && $this->queryVariablesArr['latlngor'] && $locStr && $llStr){

--- a/classes/OccurrenceManager.php
+++ b/classes/OccurrenceManager.php
@@ -271,7 +271,7 @@ class OccurrenceManager extends OccurrenceTaxaManager {
 			$this->displaySearchArr[] = $pointArr[0] . ' ' . $pointArr[1] . ' +- ' . $pointArr[2] . $pointArr[3];
 		}
 		elseif(!empty($this->searchTermArr['footprintGeoJson'])){
-			$sqlWhere .= "AND (ST_Within(p.lngLatPoint,ST_GeomFromGeoJSON('".$this->searchTermArr['footprintGeoJson']."'))) ";
+			$sqlWhere .= "AND (ST_Within(p.lngLatPoint,ST_GeomFromGeoJSON('".$this->searchTermArr['footprintGeoJson']."', 1, 0))) ";
 			$this->displaySearchArr[] = $this->LANG['POLYGON_SEARCH'];
 		}
 		if(array_key_exists('collector',$this->searchTermArr)){

--- a/classes/OccurrenceMapManager.php
+++ b/classes/OccurrenceMapManager.php
@@ -217,7 +217,7 @@ class OccurrenceMapManager extends OccurrenceManager {
 						//Set Footprint for map to load
 						$this->setSearchTerm('footprintGeoJson', $this->voucherManager->getClFootprint());
 						if(isset($this->searchTermArr['cltype']) && $this->searchTermArr['cltype'] == 'all') {
-							$sqlWhere .= "AND (ST_Within(p.lngLatPoint,ST_GeomFromGeoJSON('". $this->voucherManager->getClFootprint()." '))) ";
+							$sqlWhere .= "AND (ST_Within(p.lngLatPoint,ST_GeomFromGeoJSON('". $this->voucherManager->getClFootprint()." ', 1, 0))) ";
 						}
 					}
 				}

--- a/collections/specprocessor/standalone_scripts/custom_voucher_linker.php
+++ b/collections/specprocessor/standalone_scripts/custom_voucher_linker.php
@@ -80,7 +80,7 @@ class VoucherLinker {
 		$newest = '';
 		$newestOccid = 0;
 		$sql = 'SELECT DISTINCT o.collid, o.occid, o.recordedby, o.recordnumber, o.eventdate, o.establishmentmeans, o.decimallatitude, c.colltype ';
-		if($this->footprintGeoJson) $sql .= ',ST_Within(p.lngLatPoint,ST_GeomFromGeoJson("'.$this->footprintGeoJson.'")) as inzone ';
+		if($this->footprintGeoJson) $sql .= ',ST_Within(p.lngLatPoint,ST_GeomFromGeoJson("'.$this->footprintGeoJson.'", 1, 0)) as inzone ';
 		$sql .= 'FROM omoccurrences o INNER JOIN omcollections c ON o.collid = c.collid ';
 		if($this->footprintGeoJson) $sql .= 'LEFT JOIN omoccurpoints p ON o.occid = p.occid ';
 		$sql .= 'WHERE (o.stateprovince = "New York") AND (o.county LIKE "Bronx%" OR o.county LIKE "Kings%" OR o.county LIKE "New York%" OR o.county LIKE "Queens%" OR o.county LIKE "Richmond%") '.


### PR DESCRIPTION
- MySQL's ST_GeomFromGeoJSON supports a third srid argument, which defaults to 4326 (WGS84 datum). Point() objects don't have an SRID by default, so doing ST_WITHIN(point, geojson) throws a database error "Error number: 3033; Symbol: ER_GIS_DIFFERENT_SRIDS"
- MariaDB doesn't have documented support for different SRIDs, so the code is written without needing to account for that difference. Though it's undocumented, MariaDB does obey the third argument but it defaults to zero (tested in 11.7.2). Therefore this fix should maintain compatibility with MariaDB.

MySQL docs: https://dev.mysql.com/doc/refman/8.4/en/spatial-geojson-functions.html#function_st-geomfromgeojson
MariaDB: https://mariadb.com/docs/server/reference/sql-statements/geometry-constructors/geometry-constructors/st_geomfromgeojson

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **squash & merge** option into the `Hotfix-x.x.x` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [x] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing)

# Post-Approval

- [x] It is the code author's responsibility to merge their own pull request after it has been approved
- [x] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [x] If this PR represents a merge into the `hotfix` branch, remember to use the **squash & merge** option
- [x] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [x] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **merge** option (not squashed)
  - [x] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash)
  - [x] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [x] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch
- [x] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md)
- [x] Don't forget to delete your feature branch upon merge. Ignore this step as required

Thanks for contributing and keeping it clean!
