### PR TITLE
Closes #3073 Remove Remote DWC-Archive filesize support

### DIFF
--- a/classes/DwcArchiverPublisher.php
+++ b/classes/DwcArchiverPublisher.php
@@ -328,29 +328,11 @@ class DwcArchiverPublisher extends DwcArchiverCore{
 		$size = false;
 
 		if($fileParts = UploadUtil::decomposeUrl($filePath)) {
-			$host = $fileParts['host'] . (isset($fileParts['port'])? ':' . $fileParts['port']: '');
+			$localPath = $CLIENT_ROOT? str_replace($CLIENT_ROOT, '', $fileParts['path']): $fileParts['path'];
 
-			if($host !== $SERVER_HOST) {
-				if($headerArr = @get_headers($filePath, 1)){
-					$size = array_change_key_case($headerArr, CASE_LOWER);
-					if( strcasecmp($size[0], 'HTTP/1.1 200 OK') != 0 ) {
-						$size = $size['content-length'][1];
-					}
-					else {
-						$size = $size['content-length'];
-					}
-				}
-			} else {
-				$path = $fileParts['path'];
-
-				// If $CLIENT_ROOT is present remove from path to prevent
-				// double up as it is already in $SERVER_ROOT
-				if($CLIENT_ROOT) {
-					$path = str_replace($CLIENT_ROOT, '',$path);
-				}
-
-				$size = @filesize($SERVER_ROOT . $path);
-			}
+			if(file_exists($SERVER_ROOT . $localPath)) {
+				$size = @filesize($SERVER_ROOT . $localPath);
+			} 
 		}
 
 		return $size;


### PR DESCRIPTION
# Issue #3073 

# Summary
Will make external dwc archives not try to make header calls to get file sizes of archives.

As far as I can tell this already cannot happen based on the fact that the dwc publisher writes to the eml file using the results of `GeneralUtil::getDomain` which will always be what $SERVER_HOST is meaning there is only self hosted files. If we wish to support this the files sizes should be stored in the eml file and read out instead of fetching them dynamically.

Previous failure of this function would lock pages now the failure case is a ? mark on the size which I see as an improvement.

@themerekat If you know a case where this is being used please let me know so I can add in the remote case back.

see as

```php
$host = $fileParts['host'] . (isset($fileParts['port'])? ':' . $fileParts['port']: '');
// ...
if($case) {
 //...
} else if($host && $SERVER_HOST && $host !== $SERVER_HOST && strpos($host, $SERVER_HOST) === false) {
	if($headerArr = @get_headers($filePath, 1)){
		$size = array_change_key_case($headerArr, CASE_LOWER);
		if( strcasecmp($size[0], 'HTTP/1.1 200 OK') != 0 ) {
			$size = $size['content-length'][1];
		} else {
			$size = $size['content-length'];
		}
	}
}
```

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **squash & merge** option into the `Hotfix-x.x.x` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [x] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing)

# Post-Approval

- [x] It is the code author's responsibility to merge their own pull request after it has been approved
- [x] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [x] If this PR represents a merge into the `hotfix` branch, remember to use the **squash & merge** option
- [x] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [x] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **merge** option (not squashed)
  - [x] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash)
  - [x] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [x] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch
- [x] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md)
- [x] Don't forget to delete your feature branch upon merge. Ignore this step as required

Thanks for contributing and keeping it clean!
