### PR TITLE
Removes off-target "self" results in certain association searches

### DIFF
--- a/classes/AssociationManager.php
+++ b/classes/AssociationManager.php
@@ -102,7 +102,11 @@ class AssociationManager extends OccurrenceTaxaManager{
 
 			// External, observational, or resource associations
 			$externalAndObservationalSql = "SELECT oa.occid FROM omoccurrences o INNER JOIN omoccurassociations oa ON o.occid = oa.occid  LEFT JOIN omoccurdeterminations od ON oa.occid = od.occid " . $familyJoinStr . " WHERE (oa.associationType='observational' OR oa.associationType='externalOccurrence' OR oa.associationType='resource') AND oa.relationship " . $relationshipStr . " ";
-			if(isset($associationArr['taxa']) && isset($associationArr['search'])){
+			$searchTidsExist = isset($associationArr['taxa']) && isset($associationArr['search']) && 
+			   isset($associationArr['taxa'][$associationArr['search']]['tid']) && 
+			   is_array($associationArr['taxa'][$associationArr['search']]['tid']) && 
+			   !empty($associationArr['taxa'][$associationArr['search']]['tid']);
+			if($searchTidsExist){
 				$mainTid = array_keys($associationArr['taxa'][$associationArr['search']]['tid'])[0];
 				$tIdsNotToMatch = array($mainTid, ...$this->getAcceptedChildren($mainTid));
 				$offTargetStr = "AND o.tidinterpreted NOT IN(" . implode(',', $tIdsNotToMatch) . ") ";

--- a/classes/AssociationManager.php
+++ b/classes/AssociationManager.php
@@ -179,7 +179,6 @@ class AssociationManager extends OccurrenceTaxaManager{
 							//Return matches that are not linked to thesaurus
 							if($rankid > 179){
 								if($this->exactMatchOnly) $sqlWhereTaxa .= 'OR (o.sciname = "' . $term . '") ';
-								// else $sqlWhereTaxa .= "OR (o.sciname LIKE '" . $term . "%' AND od.isCurrent=1) OR (oa.verbatimsciname LIKE '" . $term . "%') ";
 							}
 						}
 						else{

--- a/classes/AssociationManager.php
+++ b/classes/AssociationManager.php
@@ -179,7 +179,7 @@ class AssociationManager extends OccurrenceTaxaManager{
 							//Return matches that are not linked to thesaurus
 							if($rankid > 179){
 								if($this->exactMatchOnly) $sqlWhereTaxa .= 'OR (o.sciname = "' . $term . '") ';
-								else $sqlWhereTaxa .= "OR (o.sciname LIKE '" . $term . "%' AND od.isCurrent=1) OR (oa.verbatimsciname LIKE '" . $term . "%') ";
+								// else $sqlWhereTaxa .= "OR (o.sciname LIKE '" . $term . "%' AND od.isCurrent=1) OR (oa.verbatimsciname LIKE '" . $term . "%') ";
 							}
 						}
 						else{


### PR DESCRIPTION
# Description

Fixes a bug where, when searching for associations with a taxon, if said taxon was the object in a record in the omoccurassociations table, it would show up as a spurious result in the search results page.

Also handles a second error reported in #3138.

Closes #3138. I deleted a line of code, and I was worried that it would also result in the loss of ON-target results when two samples in association with one another belonged to the same taxon. But, it seems that this was not the case. 🤞 .

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist
- [ ] Hotfixes should be branched off of the `master` branch and PR'd using the **squash & merge** option into the `Hotfix-x.x.x` branch.
- [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
    - [3138](https://github.com/Symbiota/Symbiota/issues/3138)
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing)

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **merge** option (not squashed)
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash)
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md)
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required

Thanks for contributing and keeping it clean!
