### PR TITLE
Add table to track mediaMetadata

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -572,7 +572,7 @@ class Media {
 
 
 					$storage->upload($file);
-					$createdFilepaths[] = $storage->getDirPath($file);
+					$createdFilepaths['originalUrl'] = $storage->getDirPath($file);
 
 					$urls = [
 						'thumbnailUrl' => [
@@ -599,11 +599,12 @@ class Media {
 
 							if($storage->file_exists($data['name'])) {
 								$metadata[$url] = $storage->getUrlPath($data['name']);
-								$createdFilepaths[] = $url;
+								$createdFilepaths[$url] = $storage->getDirPath($data['name']);
 							}
 
 						}
 					}
+
 					self::update_metadata($metadata, $media_metadata['mediaID'], $conn);
 				} elseif($media_type === MediaType::Audio) {
 					$storage->upload($file);
@@ -612,11 +613,15 @@ class Media {
 				}
 			}
 
+			foreach($createdFilepaths as $field => $filepath) {
+				self::insertMediaMetadata($media_metadata['mediaID'], $field, filesize($filepath), md5_file($filepath));
+			}
+
 			mysqli_commit($conn);
 		} catch(Throwable $th) {
 			mysqli_rollback($conn);
 
-			foreach($createdFilepaths as $filepath) {
+			foreach($createdFilepaths as $field => $filepath) {
 				if(file_exists($filepath)) {
 					unlink($filepath);
 				}
@@ -624,6 +629,18 @@ class Media {
 
 			array_push(self::$errors, $th->getMessage());
 		}
+	}
+
+	private static function insertMediaMetadata(int $mediaID, string $field, int $bytes, string $md5sum, ?mysqli $conn = null): void{
+		if(!$conn) {
+			$conn = Database::connect('write');
+		}
+
+		QueryUtil::executeQuery(
+			$conn,
+			'INSERT INTO mediametadata (mediaID, field, bytes, md5sum) VALUES (?, ?, ?, ?)', [
+			$mediaID, $field, $bytes, $md5sum
+		]);
 	}
 
 	public static function getMediaTypeStrFromMime(string $mime) {

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -608,8 +608,10 @@ class Media {
 					self::update_metadata($metadata, $media_metadata['mediaID'], $conn);
 				} elseif($media_type === MediaType::Audio) {
 					$storage->upload($file);
+					$createdFilepaths['originalUrl'] = $storage->getDirPath($file);
 				} elseif($media_type === MediaType::Misc) {
 					$storage->upload($file);
+					$createdFilepaths['originalUrl'] = $storage->getDirPath($file);
 				}
 			}
 

--- a/config/schema/3.0/patches/db_schema_patch-3.4.sql
+++ b/config/schema/3.0/patches/db_schema_patch-3.4.sql
@@ -616,6 +616,8 @@ CREATE TABLE mediametadata (
 	field enum ('originalUrl', 'thumbnailUrl', 'url') NOT NULL,
 	bytes BIGINT UNSIGNED NOT NULL,
 	md5sum varchar(32) NOT NULL,
+	created_at timestamp DEFAULT current_timestamp(),
+	updated_at timestamp DEFAULT NULL ON UPDATE current_timestamp(),
 	PRIMARY KEY (mediaID, field),
 	FOREIGN KEY (mediaID) REFERENCES media(mediaID) ON DELETE CASCADE
 ) ENGINE=INNODB;

--- a/config/schema/3.0/patches/db_schema_patch-3.4.sql
+++ b/config/schema/3.0/patches/db_schema_patch-3.4.sql
@@ -612,11 +612,10 @@ ALTER TABLE `omoccurrences`
 
 # Add mediaMetadata table to track metadata for media
 CREATE TABLE mediametadata (
-	metaID int UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
 	mediaID int UNSIGNED NOT NULL,
 	field enum ('originalUrl', 'thumbnailUrl', 'url') NOT NULL,
 	bytes BIGINT UNSIGNED NOT NULL,
 	md5sum varchar(32) NOT NULL,
-	CONSTRAINT UC_MediaField UNIQUE (mediaID, field),
+	PRIMARY KEY (mediaID, field),
 	FOREIGN KEY (mediaID) REFERENCES media(mediaID) ON DELETE CASCADE
 ) ENGINE=INNODB;

--- a/config/schema/3.0/patches/db_schema_patch-3.4.sql
+++ b/config/schema/3.0/patches/db_schema_patch-3.4.sql
@@ -611,11 +611,12 @@ ALTER TABLE `omoccurrences`
   ADD INDEX `IX_occurrences_verbatimCoordinates` (`collid`,`verbatimCoordinates`);
 
 # Add mediaMetadata table to track metadata for media
-CREATE TABLE mediaMetadata (
+CREATE TABLE mediametadata (
+	metaID int UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
 	mediaID int UNSIGNED NOT NULL,
 	field enum ('originalUrl', 'thumbnailUrl', 'url') NOT NULL,
 	bytes BIGINT UNSIGNED NOT NULL,
 	md5sum varchar(32) NOT NULL,
-	PRIMARY KEY (mediaID, field),
+	CONSTRAINT UC_MediaField UNIQUE (mediaID, field),
 	FOREIGN KEY (mediaID) REFERENCES media(mediaID) ON DELETE CASCADE
 ) ENGINE=INNODB;

--- a/config/schema/3.0/patches/db_schema_patch-3.4.sql
+++ b/config/schema/3.0/patches/db_schema_patch-3.4.sql
@@ -615,7 +615,7 @@ CREATE TABLE mediaMetadata (
 	mediaID int UNSIGNED NOT NULL,
 	field enum ('originalUrl', 'thumbnailUrl', 'url') NOT NULL,
 	bytes BIGINT UNSIGNED NOT NULL,
-	md5sum varchar(32),
+	md5sum varchar(32) NOT NULL,
 	PRIMARY KEY (mediaID, field),
 	FOREIGN KEY (mediaID) REFERENCES media(mediaID) ON DELETE CASCADE
 ) ENGINE=INNODB;

--- a/config/schema/3.0/patches/db_schema_patch-3.4.sql
+++ b/config/schema/3.0/patches/db_schema_patch-3.4.sql
@@ -610,3 +610,12 @@ ALTER TABLE `users`
 ALTER TABLE `omoccurrences`
   ADD INDEX `IX_occurrences_verbatimCoordinates` (`collid`,`verbatimCoordinates`);
 
+# Add mediaMetadata table to track metadata for media
+CREATE TABLE mediaMetadata (
+	mediaID int UNSIGNED NOT NULL,
+	field enum ('originalUrl', 'thumbnailUrl', 'url') NOT NULL,
+	bytes BIGINT UNSIGNED NOT NULL,
+	md5sum varchar(32),
+	PRIMARY KEY (mediaID, field),
+	FOREIGN KEY (mediaID) REFERENCES media(mediaID) ON DELETE CASCADE
+) ENGINE=INNODB;


### PR DESCRIPTION
# Summary
Adds `mediaMetadata` table to track filesizes and checksums

```sql
CREATE TABLE mediaMetadata (
	mediaID int UNSIGNED NOT NULL,
	field enum ('originalUrl', 'thumbnailUrl', 'url') NOT NULL,
	bytes BIGINT UNSIGNED NOT NULL,
	md5sum varchar(32),
	PRIMARY KEY (mediaID, field),
	FOREIGN KEY (mediaID) REFERENCES media(mediaID) ON DELETE CASCADE
) ENGINE=INNODB;
```
# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **squash & merge** option into the `Hotfix-x.x.x` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [x] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing)

# Post-Approval

- [x] It is the code author's responsibility to merge their own pull request after it has been approved
- [x] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [x] If this PR represents a merge into the `hotfix` branch, remember to use the **squash & merge** option
- [x] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [x] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **merge** option (not squashed)
  - [x] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash)
  - [x] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [x] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch
- [x] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md)
- [x] Don't forget to delete your feature branch upon merge. Ignore this step as required

Thanks for contributing and keeping it clean!
