### PR TITLE
Fix 0-border bug in Word annotation labels

### DIFF
--- a/collections/reports/defaultannotationsword.php
+++ b/collections/reports/defaultannotationsword.php
@@ -1,4 +1,7 @@
 <?php
+
+use function PHPUnit\Framework\isEmpty;
+
 include_once('../../config/symbini.php');
 include_once($SERVER_ROOT.'/classes/OccurrenceLabel.php');
 require_once $SERVER_ROOT.'/vendor/autoload.php';
@@ -58,7 +61,6 @@ $phpWord->addFontStyle('familyFont', array('size'=>8,'name'=>'Arial'));
 $phpWord->addFontStyle('identifiedFont', array('size'=>8,'name'=>'Arial'));
 $marginSize = 80;
 if(array_key_exists('marginsize',$_POST) && $_POST['marginsize']) $marginSize = 16 * $_POST['marginsize'];
-$borderWidth = 2;
 $cellLength = 20000;
 
 $sectionStyle = array();
@@ -76,19 +78,16 @@ if($columnsPerPage==3){
 }
 $section = $phpWord->addSection($sectionStyle);
 
-if(array_key_exists('borderwidth',$_POST)) $borderWidth = $_POST['borderwidth'];
-if($borderWidth) $borderWidth++;
-if($borderWidth){
-	$tableStyle['borderColor'] = '000000';
-	$tableStyle['borderSize'] = $borderWidth;
-}
-
+$borderWidth = isset($_POST['borderwidth']) ? (int)$_POST['borderwidth'] : 2;
 $outerStyle = [
   'borderColor' => '000000',
-  'borderSize'  => $borderWidth,
   'borderInsideHSize' => 0,
   'borderInsideVSize' => 0,
 ];
+if ($borderWidth > 0) {
+  $outerStyle['borderSize']  = $borderWidth;
+}
+
 $phpWord->addTableStyle('labelBox', $outerStyle);
 	
 $innerStyle = [

--- a/collections/reports/defaultannotationsword.php
+++ b/collections/reports/defaultannotationsword.php
@@ -1,5 +1,4 @@
 <?php
-
 include_once('../../config/symbini.php');
 include_once($SERVER_ROOT.'/classes/OccurrenceLabel.php');
 require_once $SERVER_ROOT.'/vendor/autoload.php';

--- a/collections/reports/defaultannotationsword.php
+++ b/collections/reports/defaultannotationsword.php
@@ -1,7 +1,5 @@
 <?php
 
-use function PHPUnit\Framework\isEmpty;
-
 include_once('../../config/symbini.php');
 include_once($SERVER_ROOT.'/classes/OccurrenceLabel.php');
 require_once $SERVER_ROOT.'/vendor/autoload.php';


### PR DESCRIPTION
# Description

Closes #3238. 

The issue appears to have been that PhpWord often treats “borderSize = 0” as “use default” and/or fails to fully clear borders. Why this was working previously is unclear to me, but it appears to be working now with the new fix.

I also removed `$tableStyle` entirely, because it was not used in assembling the final Word doc (i.e., it was cruft).

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist
- [ ] Hotfixes should be branched off of the `master` branch and PR'd using the **squash & merge** option into the `Hotfix-x.x.x` branch.
- [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
    - #3238 
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing)

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **merge** option (not squashed)
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash)
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md)
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required

Thanks for contributing and keeping it clean!
