### PR TITLE
Label add taxon order

### DIFF
--- a/classes/Manager.php
+++ b/classes/Manager.php
@@ -37,19 +37,19 @@ class Manager  {
 		}
 	}
 
-	protected function getConfigAttribute($attrName){
-		$attrValue = '';
-		if($attrName){
-			$sql = 'SELECT attributeValue FROM adminconfig WHERE attributeName = ?';
+	protected function getConfigAttribute($propName){
+		$propValue = '';
+		if($propName){
+			$sql = 'SELECT propName FROM adminproperties WHERE propName = ?';
 			if($stmt = $this->conn->prepare($sql)){
-				$stmt->bind_param('s', $attrName);
+				$stmt->bind_param('s', $propName);
 				$stmt->execute();
-				$stmt->bind_result($attrValue);
+				$stmt->bind_result($propValue);
 				$stmt->fetch();
 				$stmt->close();
 			}
 		}
-		return $attrValue;
+		return $propValue;
 	}
 
 	protected function setLogFH($logPath){

--- a/classes/OccurrenceLabel.php
+++ b/classes/OccurrenceLabel.php
@@ -147,67 +147,117 @@ class OccurrenceLabel {
 	public function getLabelArray($occidArr, $speciesAuthors = false) {
 		$retArr = array();
 		if ($occidArr) {
-			$authorArr = array();
 			$occidStr = implode(',', $occidArr);
 			if (!preg_match('/^[,\d]+$/', $occidStr)) return null;
-			$sqlWhere = 'WHERE (o.occid IN(' . $occidStr . ')) ';
-			//Get species authors for infraspecific taxa
-			$sql1 = 'SELECT o.occid, t2.author ' .
-				'FROM taxa t INNER JOIN omoccurrences o ON t.tid = o.tidinterpreted ' .
-				'INNER JOIN taxstatus ts ON t.tid = ts.tid ' .
-				'INNER JOIN taxa t2 ON ts.parenttid = t2.tid ' .
-				$sqlWhere . ' AND t.rankid > 220 AND ts.taxauthid = 1 ';
-			if (!$speciesAuthors) $sql1 .= 'AND t.unitname2 = t.unitname3 ';
-			if ($rs1 = $this->conn->query($sql1)) {
-				while ($row1 = $rs1->fetch_object()) {
-					$authorArr[$row1->occid] = $row1->author ?? '';
-				}
-				$rs1->free();
-			}
+			$authorArr = $this->getParentAuthors($occidStr, $speciesAuthors);
+			$tidArr = array();
+
 			//Get occurrence records
 			$this->setLabelFieldArr();
-			$sql2 = 'SELECT ' . implode(',', $this->labelFieldArr) . ' FROM omoccurrences o LEFT JOIN taxa t ON o.tidinterpreted = t.tid LEFT JOIN taxstatus ts ON ts.tid = o.tidinterpreted LEFT JOIN taxstatus pts ON ts.parenttid = pts.tid LEFT JOIN taxa pt ON pts.tid = pt.tid '.$sqlWhere;
-			if($rs2 = $this->conn->query($sql2)){
-				while($row2 = $rs2->fetch_assoc()){
-					$occid = $row2['occid'];
-					foreach ($row2 as $fieldName => $fieldValue) {
+			$sql = 'SELECT ' . implode(',', $this->labelFieldArr) . '
+				FROM omoccurrences o LEFT JOIN taxa t ON o.tidinterpreted = t.tid
+				LEFT JOIN taxstatus ts ON ts.tid = o.tidinterpreted
+				LEFT JOIN taxstatus pts ON ts.parenttid = pts.tid
+				LEFT JOIN taxa pt ON pts.tid = pt.tid
+				WHERE (o.occid IN(' . $occidStr . ')) ';
+			if($rs = $this->conn->query($sql)){
+				while($r = $rs->fetch_assoc()){
+					$occid = $r['occid'];
+					foreach ($r as $fieldName => $fieldValue) {
 						$retArr[$occid][strtolower($fieldName)] = $fieldValue ?? '';
 					}
 					if (array_key_exists($occid, $authorArr)) {
 						$retArr[$occid]['parentauthor'] = $authorArr[$occid];
 					}
+					if($r['tidInterpreted']) $tidArr[$r['tidInterpreted']] = $r['tidInterpreted'];
 				}
-				$rs2->free();
+				$rs->free();
 			}
-			//Append identifiers indexed within omoccurridentifier
-			if ($retArr) {
-				$sql = 'SELECT occid, identifiername, identifiervalue FROM omoccuridentifiers WHERE occid IN(' . implode(',', array_keys($retArr)) . ') ORDER BY sortBy';
+			$this->appendIdentifiers($retArr);
+			$this->appendTaxonomy($retArr, $tidArr);
+		}
+		return $retArr;
+	}
+
+	private function getParentAuthors($occidStr, $speciesAuthors){
+		//Get species authors for infraspecific taxa
+		$retArr = array();
+		$sql = 'SELECT o.occid, t2.author
+			FROM taxa t INNER JOIN omoccurrences o ON t.tid = o.tidinterpreted
+			INNER JOIN taxstatus ts ON t.tid = ts.tid
+			INNER JOIN taxa t2 ON ts.parenttid = t2.tid
+			WHERE (o.occid IN(' . $occidStr . '))  AND t.rankid > 220 AND ts.taxauthid = 1 ';
+		if (!$speciesAuthors) $sql .= 'AND t.unitname2 = t.unitname3 ';
+		if ($rs = $this->conn->query($sql)) {
+			while ($r = $rs->fetch_object()) {
+				$retArr[$r->occid] = $r->author ?? '';
+			}
+			$rs->free();
+		}
+		return $retArr;
+	}
+
+	private function appendIdentifiers(&$labelArr){
+		//Append identifiers indexed within omoccurridentifier
+		if ($labelArr) {
+			$sql = 'SELECT occid, identifiername, identifiervalue FROM omoccuridentifiers WHERE occid IN(' . implode(',', array_keys($labelArr)) . ') ORDER BY sortBy';
+			if ($rs = $this->conn->query($sql)) {
+				$otherCatArr = array();
+				$cnt = 0;
+				while ($r = $rs->fetch_object()) {
+					$otherCatArr[$r->occid][$cnt]['v'] = $r->identifiervalue;
+					$otherCatArr[$r->occid][$cnt]['n'] = $r->identifiername ?? '';
+					$cnt++;
+				}
+				$rs->free();
+				foreach ($otherCatArr as $occid => $ocnArr) {
+					$verbIdStr = '';
+					if(!empty($labelArr[$occid]['othercatalognumbers'])) $verbIdStr = $labelArr[$occid]['othercatalognumbers'];
+					$ocnStr = '';
+					foreach ($ocnArr as $idArr) {
+						$ocnStr .= '; ' . ($idArr['n'] ? $idArr['n'] . ': ' : '') . $idArr['v'];
+						$verbIdStr = str_ireplace($idArr['n'], '', $verbIdStr);
+						$verbIdStr = str_ireplace($idArr['v'], '', $verbIdStr);
+					}
+					$ocnStr = trim($ocnStr, ';,: ');
+					$verbIdStr = trim($verbIdStr, ';,: ');
+					if ($verbIdStr) $ocnStr = $ocnStr . '; ' . $verbIdStr;
+					$labelArr[$occid]['othercatalognumbers'] = $ocnStr;
+				}
+			}
+		}
+	}
+
+	private function appendTaxonomy(&$labelArr, $tidArr){
+		if($tidArr){
+			$taxonArr = array();
+			$parentArr = array(60 => 'taxonclass', 100 => 'taxonorder');
+			//Extract higher taxonomy from database
+			foreach($parentArr as $rankID => $rankName){
+				$sql = 'SELECT e.tid, p.sciname
+					FROM taxaenumtree e INNER JOIN taxa p ON e.parentTid = p.tid
+					WHERE e.tid IN(' . implode(',', $tidArr) . ') AND e.taxAuthID = 1 AND p.rankid = ' . $rankID;
 				if ($rs = $this->conn->query($sql)) {
-					$otherCatArr = array();
-					$cnt = 0;
 					while ($r = $rs->fetch_object()) {
-						$otherCatArr[$r->occid][$cnt]['v'] = $r->identifiervalue;
-						$otherCatArr[$r->occid][$cnt]['n'] = $r->identifiername ?? '';
-						$cnt++;
+						$taxonArr[$r->tid][$rankName] = $r->sciname;
 					}
 					$rs->free();
-					foreach ($otherCatArr as $occid => $ocnArr) {
-						$verbIdStr = $retArr[$occid]['othercatalognumbers'] ?? '';
-						$ocnStr = '';
-						foreach ($ocnArr as $idArr) {
-							$ocnStr .= '; ' . ($idArr['n'] ? $idArr['n'] . ': ' : '') . $idArr['v'];
-							$verbIdStr = str_ireplace($idArr['n'], '', $verbIdStr);
-							$verbIdStr = str_ireplace($idArr['v'], '', $verbIdStr);
+				}
+			}
+			if($taxonArr){
+				//Insert higher taxonomy into label output array
+				foreach($labelArr as $occid => $occurArr){
+					if($occurArr['tidinterpreted']){
+						$tid = $occurArr['tidinterpreted'];
+						if(!empty($taxonArr[$tid])){
+							foreach($taxonArr[$tid] as $rankName => $sciname){
+								$labelArr[$occid][$rankName] = $sciname;
+							}
 						}
-						$ocnStr = trim($ocnStr, ';,: ');
-						$verbIdStr = trim($verbIdStr, ';,: ');
-						if ($verbIdStr) $ocnStr = $ocnStr . '; ' . $verbIdStr;
-						$retArr[$occid]['othercatalognumbers'] = $ocnStr;
 					}
 				}
 			}
 		}
-		return $retArr;
 	}
 
 	public function exportLabelCsvFile($postArr) {
@@ -266,6 +316,7 @@ class OccurrenceLabel {
 				'family' => 'o.family',
 				'scientificName' => 'o.sciname AS scientificname',
 				'scientificName_with_author' => 'CONCAT_WS(" ",o.sciname,o.scientificnameauthorship) AS scientificname_with_author',
+				'tidInterpreted' => 'o.tidInterpreted',
 				'genus'=>'t.unitName1 AS genus',
 				'speciesName' => 'TRIM(CONCAT_WS(" ",t.unitind1,t.unitname1,t.unitind2,t.unitname2)) AS speciesname',
 				'taxonRank' => 't.unitind3 AS taxonrank',
@@ -274,6 +325,9 @@ class OccurrenceLabel {
 				'infraSpecificEpithet'=>'t.unitname3 AS infraspecificepithet',
 				'scientificNameAuthorship'=>'o.scientificnameauthorship',
 				'parentAuthor'=>'pt.author AS parentauthor',
+				'kingdom' => 't.kingdomName as kingdom',
+				'taxonClass' => '"" as taxonclass',
+				'taxonOrder' => '"" as taxonorder',
 				'identifiedBy'=>'o.identifiedby',
 				'dateIdentified' => 'o.dateidentified',
 				'identificationReferences' => 'o.identificationreferences',
@@ -377,10 +431,10 @@ class OccurrenceLabel {
 
 	private function fetchGlobalLabelJson() {
 		$status = false;
-		$sql = 'SELECT dynamicProperties FROM adminproperties WHERE attributeName = ?';
+		$sql = 'SELECT dynamicProperties FROM adminproperties WHERE propName = ?';
 		if ($stmt = $this->conn->prepare($sql)) {
-			$attributeName = 'LabelFormatJson';
-			$stmt->bind_param('s', $attributeName);
+			$propName = 'LabelFormatJson';
+			$stmt->bind_param('s', $propName);
 			$stmt->execute();
 			$stmt->bind_result($jsonResult);
 			$stmt->fetch();
@@ -674,27 +728,27 @@ class OccurrenceLabel {
 		$status = false;
 
 		$jsonDynProps = $isAlreadyDecoded ? $dataObj : json_encode($dataObj, JSON_HEX_APOS);
-		$attributeName = 'LabelFormatJson';
-		$checkSql = "SELECT COUNT(*) FROM adminproperties WHERE attributeName = ?";
+		$propName = 'LabelFormatJson';
+		$checkSql = "SELECT COUNT(*) FROM adminproperties WHERE propName = ?";
 		if ($checkStmt = $this->conn->prepare($checkSql)) {
-			$checkStmt->bind_param('s', $attributeName);
+			$checkStmt->bind_param('s', $propName);
 			$checkStmt->execute();
 			$checkStmt->bind_result($count);
 			$checkStmt->fetch();
 			$checkStmt->close();
 
 			if ($count > 0) {
-				$updateSql = "UPDATE adminproperties SET dynamicProperties = ? WHERE attributeName = ?";
+				$updateSql = "UPDATE adminproperties SET dynamicProperties = ? WHERE propName = ?";
 				if ($updateStmt = $this->conn->prepare($updateSql)) {
-					$updateStmt->bind_param('ss', $jsonDynProps, $attributeName);
+					$updateStmt->bind_param('ss', $jsonDynProps, $propName);
 					$updateStmt->execute();
 					$status = !$updateStmt->error;
 					$updateStmt->close();
 				}
 			} else {
-				$insertSql = "INSERT INTO adminproperties (attributeName, attributeValue, dynamicProperties) VALUES (?, ?, ?)";
+				$insertSql = "INSERT INTO adminproperties (propName, propValue, dynamicProperties) VALUES (?, ?, ?)";
 				if ($insertStmt = $this->conn->prepare($insertSql)) {
-					$insertStmt->bind_param('sss', $attributeName, $attributeName, $jsonDynProps);
+					$insertStmt->bind_param('sss', $propName, $propName, $jsonDynProps);
 					$insertStmt->execute();
 					$status = !$insertStmt->error;
 					$insertStmt->close();
@@ -911,7 +965,7 @@ class OccurrenceLabel {
 				if($parentAuthor){
 					$currentTxt = htmlspecialchars($parentAuthor) . ' ';
 					$textrun->addText($currentTxt, 'scientificnameauthFont');
-				} 
+				}
 				$currentTxt = $queryVal . ' ';
 				$textrun->addText($currentTxt, 'scientificnameinterFont');
 				if($shouldAddNextElement){
@@ -919,7 +973,7 @@ class OccurrenceLabel {
 					$textrun->addText($currentTxt, 'scientificnameFont');
 				}
 			}
-			
+
 		}
 	}
 }

--- a/classes/OccurrenceLabel.php
+++ b/classes/OccurrenceLabel.php
@@ -231,7 +231,7 @@ class OccurrenceLabel {
 	private function appendTaxonomy(&$labelArr, $tidArr){
 		if($tidArr){
 			$taxonArr = array();
-			$parentArr = array(60 => 'taxonclass', 100 => 'taxonorder');
+			$parentArr = array(30 => 'taxonphylum', 60 => 'taxonclass', 100 => 'taxonorder');
 			//Extract higher taxonomy from database
 			foreach($parentArr as $rankID => $rankName){
 				$sql = 'SELECT e.tid, p.sciname
@@ -326,6 +326,7 @@ class OccurrenceLabel {
 				'scientificNameAuthorship'=>'o.scientificnameauthorship',
 				'parentAuthor'=>'pt.author AS parentauthor',
 				'kingdom' => 't.kingdomName as kingdom',
+				'taxonPhylum' => '"" as taxonphylum',
 				'taxonClass' => '"" as taxonclass',
 				'taxonOrder' => '"" as taxonorder',
 				'identifiedBy'=>'o.identifiedby',

--- a/collections/reports/labeljsongui.php
+++ b/collections/reports/labeljsongui.php
@@ -427,6 +427,6 @@ header("Content-Type: text/html; charset=" . $CHARSET);
     </div>
   </main>
 </body>
-<script src="../../js/symb/collections.labeljsongui.js"></script>
+<script src="../../js/symb/collections.labeljsongui.js?ver=1"></script>
 
 </html>

--- a/js/symb/collections.labeljsongui.js
+++ b/js/symb/collections.labeljsongui.js
@@ -28,6 +28,7 @@ const fieldProps = [
     id: "othercatalognumbers",
     group: "specimen",
   },
+  { block: "labelBlock", name: "Taxon Order", id: "taxonorder", group: "taxon" },
   { block: "labelBlock", name: "Family", id: "family", group: "taxon" },
   {
     block: "labelBlock",


### PR DESCRIPTION
- Fix issue with unupdated field references associated adminproperties table
- Add kingdom name from taxa table to label output
- Add function that extracts and outputs higher taxonomic entities. Only taxon phylum, class, and order was added for the moment, but code allows for additional ranks to be easily included upon request. Can add additional terms once we evaluate performance hit with these terms. We might consider make this an optional selection. 

Addresses issue https://github.com/Symbiota/Symbiota/issues/3397
