### PR TITLE
SQL queries compatible to older MySQL versions

### DIFF
--- a/config/schema/3.0/patches/db_schema_patch-3.4.sql
+++ b/config/schema/3.0/patches/db_schema_patch-3.4.sql
@@ -54,10 +54,19 @@ ALTER TABLE `geographicthesaurus`
   ADD INDEX `FK_geothes_geolevel` (`geoLevel` ASC);
 
 #Fixes issues where Florida counties were linked to Uruguay/Florida  
-UPDATE IGNORE geographicthesaurus g INNER JOIN geographicthesaurus p ON g.parentID = p.geoThesID
-  INNER JOIN geographicthesaurus c ON g.geoThesID = c.parentID
-  SET c.parentID = (SELECT c.geoThesID FROM geographicthesaurus c INNER JOIN geographicthesaurus p ON c.parentID = p.geoThesID WHERE c.geoTerm = "Florida" AND p.geoTerm = "United States")
-  WHERE g.geoTerm IN("Florida") AND p.geoTerm = "Uruguay";
+UPDATE geographicthesaurus g INNER JOIN geographicthesaurus p ON g.parentID = p.geoThesID
+INNER JOIN geographicthesaurus c ON g.geoThesID = c.parentID
+SET c.parentID = (
+    SELECT geoThesID
+    FROM (
+        SELECT c.geoThesID
+        FROM geographicthesaurus c
+        INNER JOIN geographicthesaurus p ON c.parentID = p.geoThesID
+        WHERE c.geoTerm = 'Florida' AND p.geoTerm = 'United States'
+    ) AS t
+)
+WHERE g.geoTerm = 'Florida'
+AND p.geoTerm = 'Uruguay';
 
 DELETE c.* 
   FROM geographicthesaurus g INNER JOIN geographicthesaurus p ON g.parentID = p.geoThesID

--- a/config/schema/3.0/patches/db_schema_patch-3.4.sql
+++ b/config/schema/3.0/patches/db_schema_patch-3.4.sql
@@ -74,10 +74,19 @@ DELETE c.*
   WHERE g.geoTerm IN("Florida") AND p.geoTerm = "Uruguay";
 
 #Fixes issues where Montana counties were linked to Bulgaria/Montana  
-UPDATE IGNORE geographicthesaurus g INNER JOIN geographicthesaurus p ON g.parentID = p.geoThesID
-  INNER JOIN geographicthesaurus c ON g.geoThesID = c.parentID
-  SET c.parentID = (SELECT c.geoThesID FROM geographicthesaurus c INNER JOIN geographicthesaurus p ON c.parentID = p.geoThesID WHERE c.geoTerm = "Montana" AND p.geoTerm = "United States")
-  WHERE g.geoTerm IN("Montana") AND p.geoTerm = "Bulgaria";
+UPDATE geographicthesaurus g INNER JOIN geographicthesaurus p ON g.parentID = p.geoThesID
+INNER JOIN geographicthesaurus c ON g.geoThesID = c.parentID
+SET c.parentID = (
+    SELECT geoThesID
+    FROM (
+        SELECT c.geoThesID
+        FROM geographicthesaurus c
+        INNER JOIN geographicthesaurus p ON c.parentID = p.geoThesID
+        WHERE c.geoTerm = 'Montana' AND p.geoTerm = 'United States'
+    ) AS t
+)
+WHERE g.geoTerm = 'Montana'
+AND p.geoTerm = 'Bulgaria';
 
 DELETE c.*
   FROM geographicthesaurus g INNER JOIN geographicthesaurus p ON g.parentID = p.geoThesID
@@ -85,10 +94,19 @@ DELETE c.*
   WHERE g.geoTerm IN("Montana") AND p.geoTerm = "Bulgaria";
 
 #Fixes issues where Maryland counties were linked to Liberia/Maryland  
-UPDATE IGNORE geographicthesaurus g INNER JOIN geographicthesaurus p ON g.parentID = p.geoThesID
-  INNER JOIN geographicthesaurus c ON g.geoThesID = c.parentID
-  SET c.parentID = (SELECT c.geoThesID FROM geographicthesaurus c INNER JOIN geographicthesaurus p ON c.parentID = p.geoThesID WHERE c.geoTerm = "Maryland" AND p.geoTerm = "United States")
-  WHERE g.geoTerm IN("Maryland") AND p.geoTerm = "Liberia";
+UPDATE geographicthesaurus g INNER JOIN geographicthesaurus p ON g.parentID = p.geoThesID
+INNER JOIN geographicthesaurus c ON g.geoThesID = c.parentID
+SET c.parentID = (
+    SELECT geoThesID
+    FROM (
+        SELECT c.geoThesID
+        FROM geographicthesaurus c
+        INNER JOIN geographicthesaurus p ON c.parentID = p.geoThesID
+        WHERE c.geoTerm = 'Maryland' AND p.geoTerm = 'United States'
+    ) AS t
+)
+WHERE g.geoTerm = 'Maryland'
+AND p.geoTerm = 'Liberia';
 
 DELETE c.*
   FROM geographicthesaurus g INNER JOIN geographicthesaurus p ON g.parentID = p.geoThesID


### PR DESCRIPTION
- Add extra layer to subqueries to assist optimizer and avoid throwing error in certain versions of MySQL

Addresses issue https://github.com/Symbiota/Symbiota/issues/3405

I have tested the changes on MariaDB, thus this adjustment is not breaking anything. While I feel confident that these modifications will improve compatibility with older version of MySQL, I have not extensively tested via MySQL. Do we have a test environment we can test this on, or just trust and submit. Or we can push to the next Hotfix. This is not a critical issue. 


Please go to the `Preview` tab and select the appropriate sub-template:

* [Feature or Bugfix](?expand=1&template=feature_or_bugfix.md)
* [Hotfix](?expand=1&template=hotfix.md)
* [General Release](?expand=1&template=general_release.md)