### PR TITLE
Occurrence taxon search terms with colon fails

### DIFF
--- a/classes/OccurrenceManager.php
+++ b/classes/OccurrenceManager.php
@@ -915,11 +915,7 @@ class OccurrenceManager extends OccurrenceTaxaManager {
 			if($v) $retStr .= '&'. $this->cleanOutStr($k) . '=' . $this->cleanOutStr($v);
 		}
 		if(isset($this->taxaArr['search'])){
-			$patternTaxonChars = '/^[a-zA-Z0-9\s\-\,\.\(\)\'×†]*$/';
-			$taxonSearchTerm = $this->getTaxaSearchTerm();
-			if (preg_match($patternTaxonChars, $taxonSearchTerm)==1) {
-				$retStr .= '&taxa=' . $taxonSearchTerm;
-			}
+			$retStr .= '&taxa=' . $this->getTaxaSearchTerm();
 			if($this->taxaArr['usethes']) $retStr .= '&usethes=1';
 			if(is_numeric($this->taxaArr['taxontype'])) {
 				$retStr .= '&taxontype=' . intval($this->taxaArr['taxontype']);

--- a/classes/OccurrenceTaxaManager.php
+++ b/classes/OccurrenceTaxaManager.php
@@ -260,6 +260,8 @@ class OccurrenceTaxaManager {
 		}
 		else{
 			$taxaStr = str_replace(';',',',$this->cleanInputStr($_REQUEST['taxa']));
+			//Strip out illegal and problematic characters
+			$taxaStr = preg_replace("/[^a-zA-Z0-9\s,\-\.()'×†]/u", '', $taxaStr);
 		}
 		$taxaStr = str_replace('_', ' ',$taxaStr);
 		if($taxaStr){


### PR DESCRIPTION
- It taxon search term contains a colon (or other special characters), search will pass first validation but then the taxon term is set to null on all secondary actions.

Addresses issue https://github.com/Symbiota/Symbiota/issues/3484 

Please go to the `Preview` tab and double-click the appropriate sub-template link:

* [Feature or Bugfix](?expand=1&template=feature_or_bugfix.md)
* [Hotfix](?expand=1&template=hotfix.md)
* [General Release](?expand=1&template=general_release.md)