### PR TITLE
Sitemap collection listing adjustments

### DIFF
--- a/classes/SiteMapManager.php
+++ b/classes/SiteMapManager.php
@@ -35,24 +35,8 @@ class SiteMapManager extends Manager{
 			$sql .= 'ORDER BY collectionname';
 			$rs = $this->conn->query($sql);
 			if($rs){
-				while($row = $rs->fetch_object()){
-					$name = $row->collectionname;
-					if ($row->collectioncode){ // If there's a collection code add it after institution code
-						$name .= ' (' . $row->institutioncode . ':' . $row->collectioncode . ')';
-					}
-					else{
-						$name .= ' (' . $row->institutioncode . ')';
-					}
-					$isCollAdmin = 0;
-					if($IS_ADMIN || in_array($row->collid, $adminArr)) $isCollAdmin = 0;
-					if($row->colltype == 'Observations'){
-						$retArr['o'][$row->collid]['name'] = $name;
-						$retArr['o'][$row->collid]['isadmin'] = $isCollAdmin;
-					}
-					else{
-						$retArr['s'][$row->collid]['name'] = $name;
-						$retArr['s'][$row->collid]['isadmin'] = $isCollAdmin;
-					}
+				while($r = $rs->fetch_object()){
+					$retArr[$r->colltype][$r->collid] = $r->collectionname . ' (' . $r->institutioncode . ($r->collectioncode ? ':' . $r->collectioncode : '') . ')';
 				}
 				$rs->free();
 			}

--- a/content/lang/sitemap.en.php
+++ b/content/lang/sitemap.en.php
@@ -63,7 +63,7 @@ $LANG['CLICKEDIT'] = '(click to edit)';
 $LANG['NOPROJ'] = 'There are no projects in the system';
 $LANG['NOTEDITPROJ'] = 'You are not authorized to edit any of the Projects';
 $LANG['TAXONPROF'] = 'Taxon Profile Page';
-$LANG['THEFOLLOWINGSPEC'] = 'The following Species Profile page editing features are also available to editors via an							editing link located in the upper right of each Species Profile page.';
+$LANG['THEFOLLOWINGSPEC'] = 'The following Species Profile page editing features are also available to editors via an editing link located in the upper right of each Species Profile page.';
 $LANG['NOTAUTHOTAXONPAGE'] = 'You are not yet authorized to edit the Taxon Profile';
 $LANG['TAXONOMY'] = 'Taxonomy';
 $LANG['TAXTREE'] = 'Taxonomic Tree Viewer';
@@ -75,20 +75,21 @@ $LANG['BATCHTAXA'] = 'Batch Upload a Taxonomic Data File';
 $LANG['EOLLINK'] = 'Encyclopedia of Life Linkage Manager';
 $LANG['NOTEDITTAXA'] = 'You are not authorized to edit taxonomy';
 $LANG['CHECKLISTS'] = 'Checklists';
-$LANG['TOOLSFORMANAGE'] = 'Tools for managing Checklists are available from each checklist display page.						Editing symbols located in the upper right of the page will display						editing options for that checklist.						Below is a list of the checklists you are authorized to edit';
+$LANG['TOOLSFORMANAGE'] = 'Tools for managing Checklists are available from each checklist display page.
+	Editing symbols located in the upper right of the page will display editing options for that checklist. Below is a list of the checklists you are authorized to edit';
 $LANG['EXSICCATII'] = 'Exsiccati';
-$LANG['ESCMOD'] = 'The Exsiccati module is activated for this portal.					The exsiccati index (listed below) can be browsed or searched by everyone.					However, to add or modify exsiccati titles or series,					the user must be an administrator for at least one collection';
+$LANG['ESCMOD'] = 'The Exsiccati module is activated for this portal. The exsiccati index (listed below) can be browsed or searched by everyone.
+	However, to add or modify exsiccati titles or series, the user must be an administrator for at least one collection';
 $LANG['NOTEDITCHECK'] = 'You are not authorized to edit any of the Checklists';
-$LANG['PARA1'] = 'Tools for managing data specific to a particular collection are available through the collection\'s profile page.					Clicking on a collection name in the list below will take you to this page for that given collection.					An additional method to reach this page is by clicking on the collection name within the specimen search engine.					The editing symbol located in the upper right of Collection Profile page will open					the editing pane and display a list of editing options.';
-$LANG['COLLLIST'] = 'List of collections you have permissions to edit';
-$LANG['OBSERV'] = 'Observations';
-$LANG['NOEDITCOLL'] = 'You have no explicit editing permissions for a particular collections';
-$LANG['PARA2'] = 'Data management for observation projects is handled in a similar manner to what is described in the Collections paragraph above.                                        One difference is the General Observation project. This project serves two central purposes:                                        1) Allows registered users to submit a media-vouchered field observation.                                        2) Allows collectors to enter their own collection data for label printing and to make the data available                                        to the collections obtaining the physical specimens through donations or exchange. Visit the ';
+$LANG['COLLECTION_DESCRIPTION'] = 'Collections are organized by type (e.g., preserved specimens, fossil specimens, observations, and research field observations).
+	Research field observations represent a specialized collection type that enables field researchers to manage their data and generate labels for specimens or observations,
+	all closely linked to their user account. For more information, visit the ';
 $LANG['SYMBDOCU'] = 'Symbiota Documentation';
-$LANG['FORMOREINFO'] = 'for more information on specimen processing capabilities. Note that observation projects are not activated on all Symbiota data portals';
-$LANG['OIVS'] = 'Observation Media Voucher Submission';
-$LANG['NOOBSPROJ'] = 'There are no Observation Projects to which you have permissions';
-$LANG['OPM'] = 'Observation Project Management';
+$LANG['PRESERVED_SPECIMENS'] = 'Preserved Specimens';
+$LANG['FOSSIL_SPECIMENS'] = 'Fossil Specimens';
+$LANG['OBSERVATIONS'] = 'Observations';
+$LANG['GENERAL_OBSERVATIONS'] = 'Research Field Observations';
+$LANG['NOEDITCOLL'] = 'There are no collection for which you have editing permissions';
 $LANG['PLEASE'] = 'Please';
 $LANG['LOGIN'] = 'login';
 $LANG['TOACCESS'] = ' to access editing tools.';
@@ -109,5 +110,4 @@ $LANG['DATA_AUTHORIZED_TO_EDIT'] = 'datasets you are authorized to edit';
 $LANG['MANAGE_TAXON_THUMBNAILS'] = 'Manage Taxon Profile Map Thumbnails';
 $LANG['TAXINTER'] = 'Taxonomic Interest User Permissions ';
 $LANG['OTHER_CAT_TRANSFER'] = 'Other Catalog Number Transfer Tool';
-
 ?>

--- a/content/lang/sitemap.es.php
+++ b/content/lang/sitemap.es.php
@@ -75,20 +75,21 @@ $LANG['BATCHTAXA'] = 'Carga masiva de un archivo taxonómico';
 $LANG['EOLLINK'] = 'Gestión de enlaces al Encyclopedia of Life';
 $LANG['NOTEDITTAXA'] = 'Usted no esta autorizado/a de editar la taxonomía';
 $LANG['CHECKLISTS'] = 'Listados de especies';
-$LANG['TOOLSFORMANAGE'] = 'Herramientas para gestionar listados de especies están disponibles directamente de las páginas individuales de cada lista.Con el símbolo de editar ubicado en la esquina derecha encima de cada pagina se puede verlas opciones disponibles para editar esta lista de especies.A bajo hay un listado con todos sus derechos individuales de las listas de especies que usted esta autorizado/a de modificar';
+$LANG['TOOLSFORMANAGE'] = 'Herramientas para gestionar listados de especies están disponibles directamente de las páginas individuales de cada lista. Con el símbolo de editar ubicado en la
+	esquina derecha encima de cada pagina se puede verlas opciones disponibles para editar esta lista de especies. A bajo hay un listado con todos sus derechos individuales de las listas de especies que usted esta autorizado/a de modificar';
 $LANG['EXSICCATII'] = 'Exsiccati';
-$LANG['ESCMOD'] = 'El módulo de Exsiccati es activado para este portal.Cualquier usuario puede ver o navegar el índice de exsiccati (listado abajo) The exsiccati index (listed below).No es posible aunque añadir o modificar el título del exsiccati o de la serie,por lo menos el usuario tiene que ser administrador para una colección especifica para tener estos derechos';
+$LANG['ESCMOD'] = 'El módulo de Exsiccati es activado para este portal.Cualquier usuario puede ver o navegar el índice de exsiccati (listado abajo) The exsiccati index (listed below).
+	No es posible aunque añadir o modificar el título del exsiccati o de la serie,por lo menos el usuario tiene que ser administrador para una colección especifica para tener estos derechos';
 $LANG['NOTEDITCHECK'] = 'Usted no esta autorizado/a para editar ninguna de las listas de especies.';
-$LANG['PARA1'] = 'Herramientas para manejar datos específicos para una colección particular están disponibles por la pagina del perfil de esta colección.Hacer clic en el nombre en el listado abajo va a llevarse directamente a la pagina principal de esta colección.Alternativamente se puede acceder esta pagina es por el clic del nombre de la colección desde de la pagina de búsqueda.Con el símbolo de editar ubicado en la esquina derecha encima de cada pagina se puede abriruna ventana para modificar esta página con diferentes opciones disponibles.';
-$LANG['COLLLIST'] = 'Listado de colecciones para los cuales usted tiene derechos de modificarlos';
-$LANG['OBSERV'] = 'Observaciones';
-$LANG['NOEDITCOLL'] = 'Usted no tiene derecho explícito para editar una colección específica';
-$LANG['PARA2'] = 'La gestión de datos para proyectos de observación se maneja de manera similar a lo que se describe en el párrafo anterior sobre Colecciones.                                        Una diferencia es el proyecto de Observación General. Este proyecto tiene dos propósitos centrales: 1) Permite a los usuarios registrados enviar una observación de campo con vale medios.                                        2) Permite a los recolectores ingresar los datos de su propia colección para imprimir etiquetas y poner los datos a disposición de las colecciones obteniendo los especímenes físicos mediante donaciones o intercambio. Visita el ';
+$LANG['COLLECTION_DESCRIPTION'] = 'Las colecciones se organizan por tipo (por ejemplo: especímenes conservados, especímenes fósiles, observaciones y observaciones de campo de investigación).
+	Las observaciones de campo de investigación constituyen un tipo de colección especializado que permite a los investigadores de campo gestionar sus datos y generar etiquetas para
+	especímenes u observaciones, todo ello estrechamente vinculado a su cuenta de usuario. Para más información, visite el';
 $LANG['SYMBDOCU'] = 'documentación de Symbiota ';
-$LANG['FORMOREINFO'] = 'para más información detallada como manejar la información de muestras. Aviso importante: la funcionalidad de manejar proyectos de observaciones no es necesariamente activado para cada portal de Symbiota';
-$LANG['OIVS'] = 'Envío de vale medios de observación';
-$LANG['NOOBSPROJ'] = 'No hay proyectos de observación para los que usted posea permisos de manejo';
-$LANG['OPM'] = 'Manejo de proyectos de observaciones';
+$LANG['PRESERVED_SPECIMENS'] = 'Especímenes conservados';
+$LANG['FOSSIL_SPECIMENS'] = 'Ejemplares fósiles';
+$LANG['OBSERVATIONS'] = 'Observaciones';
+$LANG['GENERAL_OBSERVATIONS'] = 'Observaciones de campo de la investigación';
+$LANG['NOEDITCOLL'] = 'Usted no tiene derecho explícito para editar una colección específica';
 $LANG['PLEASE'] = 'Por favor';
 $LANG['LOGIN'] = 'Inicie Sesión';
 $LANG['TOACCESS'] = 'para acceder las herramientas de edición.';
@@ -109,5 +110,4 @@ $LANG['DATA_AUTHORIZED_TO_EDIT'] = 'conjuntos de datos que está autorizado a ed
 $LANG['MANAGE_TAXON_THUMBNAILS'] = 'Administrar miniaturas de mapas de perfil de taxonomía';
 $LANG['TAXINTER'] = 'Derechos de usuarios con interés taxonómico';
 $LANG['OTHER_CAT_TRANSFER'] = 'Herramienta de transferencia de otros números de catálogo';
-
 ?>

--- a/content/lang/sitemap.fr.php
+++ b/content/lang/sitemap.fr.php
@@ -75,20 +75,21 @@ $LANG['BATCHTAXA'] = 'Téléchargement par lots d\'un Fichier de Données Taxono
 $LANG['EOLLINK'] = 'Gérer Liens avec Encyclopédia of Life';
 $LANG['NOTEDITTAXA'] = 'Vous n\'êtes pas autorisé à modifier la taxonomie';
 $LANG['CHECKLISTS'] = 'Listes';
-$LANG['TOOLSFORMANAGE'] = 'Des outils de gestion des listes sont disponibles à partir de chaque page d\'affichage des listes.						Symboles d\'édition situés dans le coin supérieur droit de la page afficheront les options d\'édition						pour cette liste.						Vous trouverez ci-dessous une liste des listes que vous êtes autorisé à modifier.';
+$LANG['TOOLSFORMANAGE'] = 'Des outils de gestion des listes sont disponibles à partir de chaque page d\'affichage des listes. Symboles d\'édition situés dans le coin supérieur droit de la
+	page afficheront les options d\'édition pour cette liste. Vous trouverez ci-dessous une liste des listes que vous êtes autorisé à modifier.';
 $LANG['EXSICCATII'] = 'Exsiccati';
-$LANG['ESCMOD'] = 'Le Module Exsiccati est activé pour ce portail..					L\'index exsiccati (listé ci-dessous) peut être consulté ou recherché par tout le monde.					Cependant, pour ajouter ou modifier des titres ou des séries exsiccati,					l\'utilisateur doit être administrateur pour au moins une collection.';
+$LANG['ESCMOD'] = 'Le Module Exsiccati est activé pour ce portail. L\'index exsiccati (listé ci-dessous) peut être consulté ou recherché par tout le monde. Cependant, pour
+	ajouter ou modifier des titres ou des séries exsiccati, l\'utilisateur doit être administrateur pour au moins une collection.';
 $LANG['NOTEDITCHECK'] = 'Vous n\'êtes autorisé à modifier aucune des listes';
-$LANG['PARA1'] = 'Des outils de gestion des données spécifiques à une collection particulière sont disponibles via la page de profil de la collection.					Cliquer sur un nom de collection dans la liste ci-dessous vous amènera à cette page pour cette collection donnée.					Une méthode supplémentaire pour accéder à cette page consiste à cliquer sur le nom de la collection dans le moteur de recherche de spécimens.					Le symbole d\'édition situé en haut à droite de la page Profil de la collection s\'ouvrira					le volet d\'édition et afficher une liste d\'options d\'édition.';
-$LANG['COLLLIST'] = 'Liste des collections que vous êtes autorisé à modifier';
-$LANG['OBSERV'] = 'Observations';
-$LANG['NOEDITCOLL'] = 'Vous n\'avez pas d\'autorisations d\'édition explicites pour une collection particulière';
-$LANG['PARA2'] = 'La gestion des données pour les projets d’observation est similaire à celle décrite dans le paragraphe précédent des collections.                                        Une différence est le projet d’observation générale. Ce projet a les propositions centrales : 1) Permettre aux utilisateurs enregistrés d\'envoyer une observation de terrain avec valeur multimédia.                                        2) Permettre aux récolecteurs d\'entrer les données de leur propre collection pour imprimer les étiquettes et de mettre les données à disposition des collections en obtenant les détails physiques au moyen de dons ou d\'échanges. Visitez le ';
+$LANG['COLLECTION_DESCRIPTION'] = "Les collections sont organisées par type (par ex. : spécimens conservés, spécimens fossiles, observations et observations de terrain issues de la recherche).
+	Les observations de terrain issues de la recherche constituent un type de collection spécialisé qui permet aux chercheurs de terrain de gérer leurs données et de
+	générer des étiquettes pour les spécimens ou les observations, le tout étant étroitement lié à leur compte utilisateur. Pour plus d'informations, consultez la";
 $LANG['SYMBDOCU'] = 'Documentation Symbiote';
-$LANG['FORMOREINFO'] = 'pour plus d\'informations sur les capacités de traitement des échantillons. A noter que les projets d\'observation ne sont pas activés sur tous les portails de données Symbiota';
-$LANG['OIVS'] = 'Soumission d’un bon multimédia d’observation';
-$LANG['NOOBSPROJ'] = 'Il n\'y a pas de Projets d\'Observation pour lesquels vous avez des autorisations';
-$LANG['OPM'] = 'Gestion de Projet d\'Observation';
+$LANG['PRESERVED_SPECIMENS'] = 'Spécimens conservés';
+$LANG['FOSSIL_SPECIMENS'] = 'Spécimens fossiles';
+$LANG['OBSERVATIONS'] = 'Observations';
+$LANG['GENERAL_OBSERVATIONS'] = 'Observations de terrain';
+$LANG['NOEDITCOLL'] = 'Vous n\'avez pas d\'autorisations d\'édition explicites pour une collection particulière';
 $LANG['PLEASE'] = 'S\'il te plaît';
 $LANG['LOGIN'] = 'vous connecter';
 $LANG['TOACCESS'] = ' pour accéder aux outils d\'édition.';
@@ -109,5 +110,4 @@ $LANG['DATA_AUTHORIZED_TO_EDIT'] = 'ensembles de données que vous êtes autoris
 $LANG['MANAGE_TAXON_THUMBNAILS'] = 'Gérer les miniatures de la carte du profil de taxonomie';
 $LANG['TAXINTER'] = 'Autorisations des Utilisateurs d\'Intérêt Taxonomique';
 $LANG['OTHER_CAT_TRANSFER'] = 'Outil de transfert de numéro de catalogue autre';
-
 ?>

--- a/content/lang/sitemap.pt.php
+++ b/content/lang/sitemap.pt.php
@@ -75,21 +75,21 @@ $LANG['BATCHTAXA'] = 'Upload em Lote de um Arquivo de Dados Taxonômicos';
 $LANG['EOLLINK'] = 'Gerenciamento de Ligações de Enciclopédia do Life';
 $LANG['NOTEDITTAXA'] = 'Você não está autorizado a editar a taxonomia';
 $LANG['CHECKLISTS'] = 'Inventários Taxonômicos';
-$LANG['TOOLSFORMANAGE'] = 'Ferramentas para gerenciar listas de verificação estão disponíveis em cada página de exibição de listas de verificação.            Os símbolos de edição localizados no canto superior direito da página exibirão            opções de edição para essa lista de verificação.            Abaixo está uma lista das listas de verificação que você está autorizado a editar';
+$LANG['TOOLSFORMANAGE'] = 'Ferramentas para gerenciar listas de verificação estão disponíveis em cada página de exibição de listas de verificação. Os símbolos de edição localizados
+	no canto superior direito da página exibirão opções de edição para essa lista de verificação. Abaixo está uma lista das listas de verificação que você está autorizado a editar';
 $LANG['EXSICCATII'] = 'Exsicados';
-$LANG['ESCMOD'] = 'O módulo Exsiccati está ativado para este portal.            O índice exsiccati (listado abaixo) pode ser navegado ou pesquisado por qualquer pessoa.            No entanto, para adicionar ou modificar títulos ou séries exsicatas,            o usuário deve ser administrador de pelo menos uma coleção';
+$LANG['ESCMOD'] = 'O módulo Exsiccati está ativado para este portal. O índice exsiccati (listado abaixo) pode ser navegado ou pesquisado por qualquer pessoa. No entanto, para adicionar
+	ou modificar títulos ou séries exsicatas, o usuário deve ser administrador de pelo menos uma coleção';
 $LANG['NOTEDITCHECK'] = 'Você não está autorizado a editar nenhuma das inventários taxonômicos';
-$LANG['PARA1'] = 'Ferramentas para gerenciar dados específicos de uma coleção específica estão disponíveis na página de perfil da coleção.            Clicar no nome de uma coleção na lista abaixo o levará a esta página dessa coleção.            Um método adicional para chegar a esta página é clicar no nome da coleção no mecanismo de busca de espécimes.            O símbolo de edição localizado no canto superior direito da página Perfil da Coleção será aberto            o painel de edição e exibe uma lista de opções de edição.';
-$LANG['COLLLIST'] = 'Lista de coleções que você tem permissão para editar';
-$LANG['OBSERV'] = 'Observações';
-$LANG['NOEDITCOLL'] = 'Você não tem permissões explícitas de edição para uma coleção específica';
-$LANG['PARA2'] = 'O gerenciamento de dados para projetos de observação é semelhante ao descrito no parágrafo anterior das coleções.                                        Uma diferença é o projeto de observação geral. Este projeto segue as proposições centrais: 1) Permitir que usuários registrados enviem uma observação do terreno com valor multimídia.                                        2) Permitir que os colecionadores insiram os données de sua própria coleção para imprimir as etiquetas e fornecer os données à disposição das coleções, obtendo os detalhes físicos ao longo dos dons ou d\'échanges. Visite-o ';
+$LANG['COLLECTION_DESCRIPTION'] = 'As coleções estão organizadas por tipo (por exemplo: espécimes preservados, espécimes fósseis, observações e observações de campo de investigação).
+	As observações de campo de investigação representam um tipo de coleção especializado que permite aos investigadores de campo gerir os seus dados e gerar etiquetas para
+	espécimes ou observações, tudo isto intimamente ligado à sua conta de utilizador. Para mais informações, visite o';
 $LANG['SYMBDOCU'] = 'Documentação do Symbiota';
-$LANG['FORMOREINFO'] = 'para mais informações sobre capacidades de processamento de amostras. Observe que os projetos de observação não estão ativados em todos os portais de dados Symbiota';
-$LANG['OIVS'] = 'Envio de voucher multimídia de observação';
-$LANG['NOOBSPROJ'] = 'Não há Projetos de Observação para os quais você tenha permissão';
-$LANG['PERSONAL'] = 'Gerenciamento de amostras pessoais e recursos de impressão de etiquetas';
-$LANG['OPM'] = 'Gerenciamento de Projetos de Observação';
+$LANG['PRESERVED_SPECIMENS'] = 'Espécimes Preservados';
+$LANG['FOSSIL_SPECIMENS'] = 'Espécimes Fósseis';
+$LANG['OBSERVATIONS'] = 'Observações';
+$LANG['GENERAL_OBSERVATIONS'] = 'Observações de Campo da Pesquisa';
+$LANG['NOEDITCOLL'] = 'Você não tem permissões explícitas de edição para uma coleção específica';
 $LANG['PLEASE'] = 'Por favor';
 $LANG['LOGIN'] = 'login';
 $LANG['TOACCESS'] = 'para acessar ferramentas de edição.';

--- a/css/symbiota/sitemap.css
+++ b/css/symbiota/sitemap.css
@@ -10,7 +10,7 @@
 
 #innertext .fieldset-like .description {
     margin-left: 1.5rem;
-    padding: .25rem 0 .5rem 0;
+    padding: .25rem;
 }
 
 li {

--- a/sitemap.php
+++ b/sitemap.php
@@ -24,7 +24,7 @@ if(!$schemaVersion){
 	include_once($SERVER_ROOT.'/includes/head.php');
 	include_once($SERVER_ROOT.'/includes/googleanalytics.php');
 	?>
-	<link href="<?= $CSS_BASE_PATH ?>/symbiota/sitemap.css" type="text/css" rel="stylesheet">
+	<link href="<?= $CSS_BASE_PATH ?>/symbiota/sitemap.css?ver=1" type="text/css" rel="stylesheet">
 	<script type="text/javascript" src="js/symb/shared.js"></script>
 	<style>
 		.nested-li {
@@ -412,82 +412,32 @@ if(!$schemaVersion){
 						</span>
 					</h2>
 					<p class="description">
-						<?= $LANG['PARA1'] ?>
+						<?= $LANG['COLLECTION_DESCRIPTION'] ?>
+						<a href="https://docs.symbiota.org/Collector_Observer_Guide/" target="_blank"><?= $LANG['SYMBDOCU'] ?></a>.
 					</p>
-					<h3 class="subheader">
-						<span>
-							<?= $LANG['COLLLIST'] ?>
-						</span>
-					</h3>
 					<div>
-						<ul>
 						<?php
+						$collTypeArr = array('Preserved Specimens','Fossil Specimens','Observations','General Observations');
 						$collArr = $smManager->getCollectionList();
-						if(isset($collArr['s'])){
-							foreach($collArr['s'] as $k => $cArr){
-								echo '<li>';
-								echo '<a href="' . $CLIENT_ROOT . '/collections/misc/collprofiles.php?collid=' . $k . '&emode=1">';
-								echo $cArr['name'];
-								echo '</a>';
-								echo '</li>';
+						if($collArr){
+							foreach($collTypeArr as $collTypeStr){
+								if(isset($collArr[$collTypeStr])){
+									$headerStr = $collTypeStr;
+									$langKey = str_replace(' ', '_', strtoupper($headerStr));
+									if(isset($LANG[$langKey])) $headerStr = $LANG[$langKey];
+									echo '<h3 class="subheader"><span>' . $headerStr . '</span></h3>';
+									echo '<ul>';
+									foreach($collArr[$collTypeStr] as $collid => $collName){
+										echo '<li><a href="' . $CLIENT_ROOT . '/collections/misc/collprofiles.php?collid=' . $collid . '&emode=1" >' .$collName. '</a></li>';
+									}
+									echo '</ul>';
+								}
 							}
 						}
 						else{
-							echo "<li>".$LANG['NOEDITCOLL']."</li>";
+							echo '<li>' . $LANG['NOEDITCOLL'] . '</li>';
 						}
 						?>
-						</ul>
-					</div>
-
-					<h2 class="subheader">
-						<span>
-							<?= $LANG['OBSERV'] ?>
-						</span>
-					</h2>
-					<p class="description">
-						<?= $LANG['PARA2'] ?>
-						<a href="https://docs.symbiota.org/Collector_Observer_Guide/" target="_blank"><?= $LANG['SYMBDOCU'] ?></a> <?= $LANG['FORMOREINFO'] ?>.
-					<p class="description">
-					<h3 class="subheader">
-						<span>
-							<?= $LANG['OIVS'] ?>
-						</span>
-					</h3>
-					<div>
-						<ul>
-							<?php
-							$obsManagementStr = '';
-							if(isset($collArr['o'])){
-								foreach($collArr['o'] as $k => $oArr){
-									?>
-									<li>
-										<a href="collections/editor/observationsubmit.php?collid=<?= $k ?>">
-											<?= $oArr['name'] ?>
-										</a>
-									</li>
-									<?php
-									if($oArr['isadmin']) $obsManagementStr .= '<li><a href="collections/misc/collprofiles.php?collid=' . $k . '&emode=1">' . htmlspecialchars($oArr['name'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . "</a></li>\n";
-								}
-							}
-							else{
-								echo '<li>' . $LANG['NOOBSPROJ'] . '</li>';
-							}
-							?>
-						</ul>
-						<?php
-						if($obsManagementStr){
-							?>
-							<h3 class="subheader">
-								<span>
-									<?= $LANG['OPM'] ?>
-								</span>
-							</h3>
-							<ul>
-								<?= $obsManagementStr ?>
-							</ul>
-						<?php
-						}
-					?>
 					</div>
 					<?php
 				}


### PR DESCRIPTION
- Revamp collection listing to display in groups based on collection type (collType), rather than codes predefined within code (e.g. collection / observation)
- Reduce wording in preference to directing user to SSH documentation  
- Add LANG translations for collection types
- Adjust LANG files to match new descriptions

Addresses issue https://github.com/Symbiota/Symbiota/issues/3268

Examples of new display of collections: 
<img width="2286" height="1738" alt="image" src="https://github.com/user-attachments/assets/815c5d07-007b-47ec-af52-bebdb70a2588" />

In Spanish: 
<img width="2315" height="1651" alt="image" src="https://github.com/user-attachments/assets/5098c9f9-fa23-4a59-83b0-d128d2e0cfc2" />


Please go to the `Preview` tab and double-click the appropriate sub-template link:

* [Feature or Bugfix](?expand=1&template=feature_or_bugfix.md)
* [Hotfix](?expand=1&template=hotfix.md)
* [General Release](?expand=1&template=general_release.md)