### PR TITLE
Guard imgDiv access and bump script version

### DIFF
--- a/js/symb/taxa.index.js
+++ b/js/symb/taxa.index.js
@@ -6,7 +6,7 @@ $(document).ready(function() {
 	$("#desctabs").show();
 
 	var imgDiv = document.getElementById("img-div");
-	if(imgDiv.scrollHeight > imgDiv.clientHeight) document.getElementById("img-tab-div").style.display = 'block'; 
+	if(imgDiv && imgDiv.scrollHeight > imgDiv.clientHeight) document.getElementById("img-tab-div").style.display = 'block'; 
 
 });
 

--- a/taxa/index.php
+++ b/taxa/index.php
@@ -67,7 +67,7 @@ if($SYMB_UID){
 	?>
 	<script src="<?php echo $CLIENT_ROOT; ?>/js/jquery-3.7.1.min.js" type="text/javascript"></script>
 	<script src="<?php echo $CLIENT_ROOT; ?>/js/jquery-ui.min.js" type="text/javascript"></script>
-	<script src="../js/symb/taxa.index.js?ver=202101" type="text/javascript"></script>
+	<script src="../js/symb/taxa.index.js?ver=202606" type="text/javascript"></script>
 	<script src="../js/symb/taxa.editor.js?ver=202101" type="text/javascript"></script>
 	<style type="text/css">
 		.resource-title{ font-weight: bold; }


### PR DESCRIPTION
Minor error where when img-div is not rendered (which happens when taxonRank is above 180), JS will throw an error. 