### PR TITLE
Fix Naming Issue with UploadUtil ZipMimes

### DIFF
--- a/classes/TaxonomyUpload.php
+++ b/classes/TaxonomyUpload.php
@@ -63,7 +63,7 @@ class TaxonomyUpload{
 			try {
 				UploadUtil::checkFileUpload(
 					$_FILES['uploadfile'],
-					UploadUtil::ALLOWED_ZIP_MIMES
+					UploadUtil::ALLOWED_BATCH_PROCESSING_MIMES
 				);
 			} catch(Exception $e) {
 				$this->errorStr = 'ERROR: ' . $e->getMessage();

--- a/classes/utilities/UploadUtil.php
+++ b/classes/utilities/UploadUtil.php
@@ -23,7 +23,10 @@ class UploadUtil {
 		'audio/mpeg', 'audio/wav', 'audio/ogg'
 	];
 
-	const ALLOWED_ZIP_MIMES = [
+	// Often a CSV or Zipped CSV(s)
+	// Used:
+	// - Taxonomy Upload
+	const ALLOWED_BATCH_PROCESSING_MIMES = [
 		'application/x-zip',
 		'application/zip',
 		'application/x-zip-compressed',


### PR DESCRIPTION
# Problem
ZIP Mimes covers csvs as well so I renamed this variable to be clear.

This isn't super impactful but helps document how/what is being used which will prevent accidental log bugs from cropping up.