### PR TITLE
Visual label editor bugfix

### DIFF
--- a/collections/reports/labeljsongui.php
+++ b/collections/reports/labeljsongui.php
@@ -427,6 +427,6 @@ header("Content-Type: text/html; charset=" . $CHARSET);
     </div>
   </main>
 </body>
-<script src="../../js/symb/collections.labeljsongui.js?ver=1"></script>
+<script src="../../js/symb/collections.labeljsongui.js?ver=2"></script>
 
 </html>

--- a/collections/reports/labelprofile.php
+++ b/collections/reports/labelprofile.php
@@ -108,6 +108,19 @@ $isGeneralObservation = (($labelManager->getMetaDataTerm('colltype') == 'General
 					editorWindow.loadJson();
 				}
 			}
+
+			function validateJsonForm(jsonForm) {
+				let jsonString = jsonForm.elements['json'].value;
+
+				try {
+					JSON.parse(jsonString);
+					return true; // Allows form submission
+				} catch (error) {
+					alert('Invalid JSON! Please correct it: ' . error.message);
+					return false; // Blocks form submission
+				}
+			}
+
 		</script>
 		<style>
 			fieldset{ width:800px; padding:15px; }

--- a/js/symb/collections.labeljsongui.js
+++ b/js/symb/collections.labeljsongui.js
@@ -168,7 +168,7 @@ const fieldProps = [
   {
     block: 'labelBlock',
     name: 'Description',
-    id: 'verbatimAttributes',
+    id: 'verbatimattributes',
     group: 'specimen',
   },
   { block: "labelBlock", name: "Behavior", id: "behavior", group: "specimen" },
@@ -193,7 +193,7 @@ const fieldProps = [
   {
     block: "labelBlock",
     name: "Life Stage",
-    id: "lifeStage",
+    id: "lifestage",
     group: "specimen",
   },
   { block: "labelBlock", name: "Sex", id: "sex", group: "specimen" },
@@ -1221,7 +1221,7 @@ function saveJson() {
   let formatId = dummy.dataset.formatId;
   let formatTextArea = window.opener.document.querySelector(formatId);
   let list = refreshPreview();
-  let isEmpty = list[0].length == 0;
+  let isEmpty = list.length == 0;
   let message = "";
   if (isEmpty) {
     alert(


### PR DESCRIPTION
Fixes issue in the visual label profile editor that was preventing fields from rendering when placed after verbatimAttributes. Addresses #3652

# Pull Request Checklist:

- [x] There are **no linter errors**
- [x] [**Symbiota coding standards**](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] Comment which **GitHub issue(s)**, if any does this PR address

## Post-Approval

- [x] It is the code author's responsibility to **merge** their own pull request after it has been approved