### PR TITLE
Chore: Bump checkout and upload-artifact to v7

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -47,7 +47,6 @@ jobs:
 
   playwright:
     strategy:
-      max-parallel: 1
       matrix:
         browser: [chromium, firefox, webkit]
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -47,6 +47,7 @@ jobs:
 
   playwright:
     strategy:
+      max-parallel: 1
       matrix:
         browser: [chromium, firefox, webkit]
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: 'ubuntu-latest'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: 'Setup Testing Database Config'
       run : mv config/dbconnection_testing_template.php config/dbconnection.php
@@ -53,7 +53,7 @@ jobs:
     runs-on: 'ubuntu-latest'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: 'Setup Testing Database Config'
       run : mv config/dbconnection_testing_template.php config/dbconnection.php
@@ -84,7 +84,7 @@ jobs:
     - name: 'Run Playwright Tests'
       run: docker run --rm -v .:/var/www/html --network=host --ipc=host mcr.microsoft.com/playwright:v1.56.0-noble /bin/bash -c "cd /var/www/html && npm install @playwright/test@1.56.0 mysql2@3.16.0 --save-dev && npx playwright test --project=${{ matrix.browser }}"
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: ${{ !cancelled() }}
       with:
         name: playwright-report-${{ matrix.browser }}

--- a/classes/utilities/TaxonomyUtil.php
+++ b/classes/utilities/TaxonomyUtil.php
@@ -1,7 +1,7 @@
 <?php
 include_once($SERVER_ROOT.'/config/dbconnection.php');
 include_once($SERVER_ROOT.'/traits/TaxonomyTrait.php');
-include_once($SERVER_ROOT.'/classes/Sanitize.php');
+include_once($SERVER_ROOT.'/classes/utilities/Sanitize.php');
 
 class TaxonomyUtil {
 

--- a/tests/e2e/pages/CollectionSearch.ts
+++ b/tests/e2e/pages/CollectionSearch.ts
@@ -119,12 +119,15 @@ class SymbCollectionSearchPage extends CollectionSearchPage {
 	async selectCollection(collId: number): Promise<void> {
 		const expand = this.page.locator('span[id*="open_toggle"]');
 		for (const el of await expand.all()) {
-			await el.isVisible();
+			await expect(el).toBeVisible();
+			await expect(el).toBeEnabled();
 			await el.click({force: true});
 		}
 
 		const checkbox = this.page.locator(`input[name="db[]"][value="${collId}"]`);
-		await checkbox.isVisible();
+		await expect(checkbox).toBeVisible();
+		await expect(checkbox).toBeEnabled();
+
 		await checkbox.setChecked(true, {force: true});
 	}
 


### PR DESCRIPTION
# Summary
Small ci change to bump to most recent checkout and upload artifact runners.
Fixes a import error introduce by a clean up pr
Adds expects to visible and disabled for collections ui in search
