### PR TITLE
Hotfix backups timing out

### DIFF
--- a/classes/DwcArchiverCore.php
+++ b/classes/DwcArchiverCore.php
@@ -2452,6 +2452,11 @@ class DwcArchiverCore extends Manager{
 		return $this->dwcaOutputUrl;
 	}
 
+	public function getTargetPath(){
+		if(!$this->targetPath) $this->setTargetPath();
+		return $this->targetPath;
+	}
+
 	//Output cleaning functions
 	protected function encodeArr(&$inArr){
 		if ($this->charSetSource && $this->charSetOut != $this->charSetSource) {

--- a/classes/DwcArchiverCore.php
+++ b/classes/DwcArchiverCore.php
@@ -25,6 +25,7 @@ class DwcArchiverCore extends Manager{
 	protected $conditionArr = array();
 	private $applyConditionLimit = false;
 	private $observerUid = 0;				//If set, this is a backup event of personally managed specimens
+	private $remotePubDetails = null;
 
 	private $targetPath;
 	protected $serverDomain;
@@ -1730,9 +1731,9 @@ class DwcArchiverCore extends Manager{
 		$fileUrl = $this->dwcaOutputUrl;
 		$domainName = $this->serverDomain;
 		$ipAddress = $_SERVER['REMOTE_ADDR'];
-		$sql = 'INSERT INTO omexport(uid, category, tagName, queryTerms, fileUrl, portalDomain, expiration, ipAddress) VALUES(?, ?, ?, ?, ?, ?, DATE_ADD(NOW(), INTERVAL 7 DAY), ?)';
+		$sql = 'INSERT INTO omexport(uid, category, tagName, queryTerms, fileUrl, portalDomain, expiration, ipAddress, notes) VALUES(?, ?, ?, ?, ?, ?, DATE_ADD(NOW(), INTERVAL 7 DAY), ?, ?)';
 		if($stmt = $this->conn->prepare($sql)){
-			$stmt->bind_param('issssss', $uid, $this->schemaType, $tagName, $queryTerms, $fileUrl, $domainName, $ipAddress);
+			$stmt->bind_param('isssssss', $uid, $this->schemaType, $tagName, $queryTerms, $fileUrl, $domainName, $ipAddress, $this->remotePubDetails);
 			try{
 				if($stmt->execute()){
 					if($stmt->affected_rows || !$stmt->error){
@@ -2217,11 +2218,13 @@ class DwcArchiverCore extends Manager{
 		return $bool;
 	}
 
-	public function isAuthorized(){
+	public function isAuthorized($source){
+		$this->remotePubDetails = 'source: ' . $source;
 		if($_SERVER['SERVER_NAME'] == 'localhost'){
 			//Is a dev environment
 			//Note: Under Apache 2, UseCanonicalName = On and ServerName must be set.
 			//Otherwise, this value reflects the hostname supplied by the client, which can be spoofed. It is not safe to rely on this value in security-dependent contexts.
+			$this->remotePubDetails .= ', SERVER_NAME: localhost';
 			return true;
 		}
 
@@ -2234,6 +2237,7 @@ class DwcArchiverCore extends Manager{
 		//error_log('Access to dwcapubhandler - refererIpPrefix: ' . $refererIpPrefix . '; serverIP: ' . $_SERVER['SERVER_ADDR']);
 		if(!empty($_SERVER['SERVER_ADDR']) && $refererIpPrefix){
 			if(strpos($_SERVER['SERVER_ADDR'], $refererIpPrefix) === 0){
+				$this->remotePubDetails .= ', status: within network';
 				return true;
 			}
 		}
@@ -2248,13 +2252,17 @@ class DwcArchiverCore extends Manager{
 		$portalIndex = $this->getPortalIndex();
 		foreach($portalIndex as $indexDomain){
 			$indexDomain = str_replace('www.', '', parse_url($indexDomain, PHP_URL_HOST));
-			if($refererDomain == $indexDomain) return true;
+			if($refererDomain == $indexDomain){
+				$this->remotePubDetails .= ', referer: ' . $refererUrl;
+				return true;
+			}
 		}
 
 		//Check to see if user is logged in or user token is included
 		if($GLOBALS['SYMB_UID']) return true;
 		if(!empty($_REQUEST['token'])){
-			if($this->validateUserToken($_REQUEST['token'])){
+			if($uid = $this->validateUserToken($_REQUEST['token'])){
+				$this->remotePubDetails .= ', uid: ' . $uid;
 				return true;
 			}
 			else{
@@ -2283,17 +2291,17 @@ class DwcArchiverCore extends Manager{
 	}
 
 	private function validateUserToken($userToken){
-		$authorized = false;
+		$uid = 0;
 		$userToken = $_REQUEST['token'];
-		$sql = 'SELECT tokenID FROM useraccesstokens WHERE token = ?';
+		$sql = 'SELECT uid FROM useraccesstokens WHERE token = ?';
 		if($stmt = $this->conn->prepare($sql)){
 			$stmt->bind_param('s', $userToken);
 			$stmt->execute;
-			$stmt->store_result();
-			if($stmt->num_rows) $authorized = true;
+			$stmt->bind_result($uid);
+			$stmt->fetch();
 			$stmt->close();
 		}
-		return $authorized;
+		return $uid;
 	}
 
 	//setters and getters

--- a/classes/DwcArchiverCore.php
+++ b/classes/DwcArchiverCore.php
@@ -1723,8 +1723,13 @@ class DwcArchiverCore extends Manager{
 		$uid = $GLOBALS['SYMB_UID'];
 		$tagName = 'UID-' . $uid;
 		if(!$uid){
-			$uid = null;
-			$tagName = $_SERVER['REMOTE_ADDR'] . '-' . time();
+			if(preg_match('/uid:\s(\d+)/', $this->remotePubDetails, $m)){
+				$uid = $m[1];
+			}
+			else{
+				$uid = null;
+				$tagName = $_SERVER['REMOTE_ADDR'] . '-' . time();
+			}
 		}
 		$tagName .= '-' . time();
 		$queryTerms = $this->conditionSql;
@@ -2220,6 +2225,7 @@ class DwcArchiverCore extends Manager{
 
 	public function isAuthorized($source){
 		$this->remotePubDetails = 'source: ' . $source;
+
 		if($_SERVER['SERVER_NAME'] == 'localhost'){
 			//Is a dev environment
 			//Note: Under Apache 2, UseCanonicalName = On and ServerName must be set.
@@ -2243,18 +2249,16 @@ class DwcArchiverCore extends Manager{
 		}
 
 		//Check if referer is registered within portal index
-		if(empty($_SERVER['HTTP_REFERER'])){
-			error_log('Unauthorized access to dwcapubhandler: NULL HTTP_REFERER');
-			return false;
-		}
-		$refererUrl = $_SERVER['HTTP_REFERER'];
-		$refererDomain = str_replace('www.', '', parse_url($refererUrl, PHP_URL_HOST));
-		$portalIndex = $this->getPortalIndex();
-		foreach($portalIndex as $indexDomain){
-			$indexDomain = str_replace('www.', '', parse_url($indexDomain, PHP_URL_HOST));
-			if($refererDomain == $indexDomain){
-				$this->remotePubDetails .= ', referer: ' . $refererUrl;
-				return true;
+		if(!empty($_SERVER['HTTP_REFERER'])){
+			$refererUrl = $_SERVER['HTTP_REFERER'];
+			$refererDomain = str_replace('www.', '', parse_url($refererUrl, PHP_URL_HOST));
+			$portalIndex = $this->getPortalIndex();
+			foreach($portalIndex as $indexDomain){
+				$indexDomain = str_replace('www.', '', parse_url($indexDomain, PHP_URL_HOST));
+				if($refererDomain == $indexDomain){
+					$this->remotePubDetails .= ', referer: ' . $refererUrl;
+					return true;
+				}
 			}
 		}
 
@@ -2292,11 +2296,10 @@ class DwcArchiverCore extends Manager{
 
 	private function validateUserToken($userToken){
 		$uid = 0;
-		$userToken = $_REQUEST['token'];
 		$sql = 'SELECT uid FROM useraccesstokens WHERE token = ?';
 		if($stmt = $this->conn->prepare($sql)){
 			$stmt->bind_param('s', $userToken);
-			$stmt->execute;
+			$stmt->execute();
 			$stmt->bind_result($uid);
 			$stmt->fetch();
 			$stmt->close();

--- a/classes/DwcArchiverOccurrence.php
+++ b/classes/DwcArchiverOccurrence.php
@@ -475,7 +475,7 @@ class DwcArchiverOccurrence extends Manager{
 				$sql = 'UPDATE omexportoccurrences x INNER JOIN taxaenumtree e ON x.taxonID = e.tid
 					INNER JOIN taxa t ON e.parentTid = t.tid
 					SET x.' . $fieldName . ' = t.sciname
-					WHERE x.omExportID = ? AND t.rankid = ?';
+					WHERE e.taxAuthID = 1 AND x.omExportID = ? AND t.rankid = ?';
 				if($stmt = $this->conn->prepare($sql)){
 					try{
 						$stmt->bind_param('ii', $this->exportID, $rankID);
@@ -558,7 +558,7 @@ class DwcArchiverOccurrence extends Manager{
 			$sql = 'UPDATE omexportoccurrences x INNER JOIN taxstatus ts ON x.taxonID = ts.tid
 				INNER JOIN taxa t ON ts.tidaccepted = t.tid
 				SET x.acceptedNameUsageID = t.tid, x.acceptedNameUsage = t.sciname, x.acceptedNameUsageAuthorship = t.author
-				WHERE x.omExportID = ?';
+				WHERE ts.taxAuthID = 1 AND x.omExportID = ?';
 			if($stmt = $this->conn->prepare($sql)){
 				try{
 					$stmt->bind_param('i', $this->exportID);

--- a/collections/download/downloadhandler.php
+++ b/collections/download/downloadhandler.php
@@ -26,49 +26,7 @@ if ($token) {
 	]);
 }
 
-if ($schema == 'backup') {
-	$collid = $_POST['collid'];
-	if ($collid && is_numeric($collid)) {
-		//check permissions due to sensitive localities not being redacted
-		if ($IS_ADMIN || (array_key_exists('CollAdmin', $USER_RIGHTS) && in_array($collid, $USER_RIGHTS['CollAdmin']))) {
-			$dwcaHandler = new DwcArchiverCore();
-			$dwcaHandler->setSchemaType('backup');
-			$dwcaHandler->setCharSetOut($cSet);
-			$dwcaHandler->setVerboseMode(0);
-			$dwcaHandler->setIncludeDets(1);
-			$dwcaHandler->setIncludeImgs(1);
-			$dwcaHandler->setIncludeAttributes(1);
-			$dwcaHandler->setIncludeMaterialSample(1);
-			$dwcaHandler->setIncludeIdentifiers(1);
-			$dwcaHandler->setIncludeAssociations(1);
-			$dwcaHandler->setRedactLocalities(0);
-			$dwcaHandler->setCollArr($collid);
-
-			$archiveFile = $dwcaHandler->createDwcArchive();
-
-			if ($archiveFile) {
-				ob_start();
-				ob_clean();
-				ob_end_flush();
-				header('Content-Description: Symbiota Occurrence Backup File (DwC-Archive data package)');
-				header('Content-Type: application/zip');
-				header('Content-Disposition: attachment; filename=' . basename($archiveFile));
-				header('Content-Transfer-Encoding: binary');
-				header('Expires: 0');
-				header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
-				header('Pragma: public');
-				header('Content-Length: ' . filesize($archiveFile));
-				//od_end_clean();
-				readfile($archiveFile);
-				unlink($archiveFile);
-			} else {
-				$errMsg = $dwcaHandler->getErrorMessage();
-				if($errMsg) echo $errMsg;
-				else echo 'ERROR creating output file. Query probably did not include any records.';
-			}
-		}
-	}
-} else {
+if ($schema != 'backup') {
 	$zip = (array_key_exists('zip', $_POST) ? $_POST['zip'] : 0);
 	$allowedFormats = ['csv', 'tab'];
 	$formatFromPost = (array_key_exists('format', $_POST) ? $_POST['format'] : 'csv');

--- a/collections/misc/collbackup.php
+++ b/collections/misc/collbackup.php
@@ -48,6 +48,17 @@ if($isEditor){
 	<?php
 	include_once($SERVER_ROOT . '/includes/head.php');
 	?>
+	<script>
+		function fileDownloaded(){
+			let linkElem = document.getElementById("download-link");
+			linkElem.style.pointerEvents = 'none';
+			linkElem.style.opacity = '0.5';
+			linkElem.setAttribute('tabindex', '-1');
+			linkElem.setAttribute('aria-disabled', 'true');
+			alert("<?= $LANG['DOWNLOAD_COMPLETE'] ?>");
+			window.close();
+		}
+	</script>
     <style>
     	fieldset{ padding:15px;width:350px }
     	legend{ font-weight: bold }
@@ -78,7 +89,12 @@ if($isEditor){
 
 					if ($archiveFile) {
 						$filename = substr($archiveFile, strrpos($archiveFile, '/') + 1);
-						echo $LANG['BACKUP_FILE'] . ': <a href="collbackup.php?bufile=' . $filename . '">' . $filename . '</a>';
+						?>
+						<div>
+							<?= $LANG['BACKUP_FILE'] ?>:
+							<a id="download-link" href="collbackup.php?bufile=<?= $filename ?>" onclick="fileDownloaded()"><?= $filename ?></a>
+						</div>
+						<?php
 					} else {
 						$errMsg = $dwcaHandler->getErrorMessage();
 						if($errMsg) echo $errMsg;
@@ -96,7 +112,7 @@ if($isEditor){
 							<input type="radio" id="cset2" name="cset" value="utf-8" <?= (!$cSet || $cSet == 'utf8' ? 'checked' : ''); ?> /> <label for="cset2">UTF-8 (unicode)</label>
 						</div>
 						<div>
-							<div style="float:left">
+							<div>
 								<input type="hidden" name="collid" value="<?= $collid; ?>">
 								<button type="submit" name="formsubmit" value="preformBackup"><?= $LANG['DOWNLOAD'] ?></button>
 							</div>

--- a/collections/misc/collbackup.php
+++ b/collections/misc/collbackup.php
@@ -50,11 +50,7 @@ if($isEditor){
 	?>
 	<script>
 		function fileDownloaded(){
-			let linkElem = document.getElementById("download-link");
-			linkElem.style.pointerEvents = 'none';
-			linkElem.style.opacity = '0.5';
-			linkElem.setAttribute('tabindex', '-1');
-			linkElem.setAttribute('aria-disabled', 'true');
+			document.getElementById("download-link").style.pointerEvents = 'none';
 			alert("<?= $LANG['DOWNLOAD_COMPLETE'] ?>");
 			window.close();
 		}

--- a/collections/misc/collbackup.php
+++ b/collections/misc/collbackup.php
@@ -1,5 +1,6 @@
 <?php
 include_once('../../config/symbini.php');
+include_once($SERVER_ROOT . '/classes/DwcArchiverPublisher.php');
 include_once($SERVER_ROOT . '/classes/utilities/Language.php');
 
 Language::load('collections/misc/collbackup');
@@ -7,8 +8,9 @@ Language::load('collections/misc/collbackup');
 header('Content-Type: text/html; charset=' . $CHARSET);
 
 $collid = isset($_REQUEST['collid']) ? filter_var($_REQUEST['collid'], FILTER_SANITIZE_NUMBER_INT) : 0;
-$action = isset($_REQUEST['formsubmit']) ? $_REQUEST['formsubmit'] : '';
-$cSet = isset($_REQUEST['cset']) ? $_REQUEST['cset'] : '';
+$action = isset($_POST['formsubmit']) ? $_POST['formsubmit'] : '';
+$cSet = isset($_POST['cset']) ? $_POST['cset'] : '';
+$backupFile = isset($_REQUEST['bufile']) ? $_REQUEST['bufile'] : '';
 
 $isEditor = 0;
 if($IS_ADMIN){
@@ -16,6 +18,27 @@ if($IS_ADMIN){
 }
 elseif($collid && isset($USER_RIGHTS['CollAdmin']) && in_array($collid, $USER_RIGHTS['CollAdmin'])){
 	$isEditor = 1;
+}
+if($isEditor){
+	if(preg_match('/_backup_\d{4}-\d{2}-\d{2}_\d{6}_DwC-A\.zip$/', $backupFile)){
+		$dwcaHandler = new DwcArchiverCore();
+		$path = $dwcaHandler->getTargetPath();
+		$archiveFile = $path . $backupFile;
+		while (ob_get_level()) {
+			ob_end_clean();
+		}
+		header('Content-Description: ' . $LANG['OCCURRENCE_BAKUP_FILE']);
+		header('Content-Type: application/zip');
+		header('Content-Disposition: attachment; filename=' . basename($archiveFile));
+		header('Content-Transfer-Encoding: binary');
+		header('Expires: 0');
+		header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
+		header('Pragma: public');
+		header('Content-Length: ' . filesize($archiveFile));
+		readfile($archiveFile);
+		unlink($archiveFile);
+		exit;
+	}
 }
 ?>
 <!DOCTYPE html>
@@ -25,13 +48,6 @@ elseif($collid && isset($USER_RIGHTS['CollAdmin']) && in_array($collid, $USER_RI
 	<?php
 	include_once($SERVER_ROOT . '/includes/head.php');
 	?>
-    <script>
-    	function submitBuForm(f){
-			f.formsubmit.disabled = true;
-			document.getElementById("workingdiv").style.display = "block";
-			return true;
-    	}
-    </script>
     <style>
     	fieldset{ padding:15px;width:350px }
     	legend{ font-weight: bold }
@@ -41,30 +57,54 @@ elseif($collid && isset($USER_RIGHTS['CollAdmin']) && in_array($collid, $USER_RI
 </head>
 <body>
 	<div role="main" id="innertext">
-		<h1 class="page-heading screen-reader-only"><?php echo $LANG['DOWNLOAD_MODULE']; ?></h1>
+		<h1 class="page-heading screen-reader-only"><?= $LANG['DOWNLOAD_MODULE'] ?></h1>
 		<?php
 		if($isEditor){
-			?>
-			<form name="buform" action="../download/downloadhandler.php" method="post" onsubmit="return submitBuForm(this);">
-				<fieldset>
-					<legend><?= $LANG['DOWNLOAD_MODULE'] ?></legend>
-					<div style="height:50px; margin: 10px">
-						<input type="radio" id="cset1" name="cset" value="iso-8859-1" <?= ($cSet == 'iso88591' ? 'checked' : ''); ?> /> <label for="cset1">ISO-8859-1 (western)</label><br/>
-						<input type="radio" id="cset2" name="cset" value="utf-8" <?= (!$cSet || $cSet == 'utf8' ? 'checked' : ''); ?> /> <label for="cset2">UTF-8 (unicode)</label>
-					</div>
-					<div>
-						<div style="float:left">
-							<input type="hidden" name="collid" value="<?= $collid; ?>">
-							<input type="hidden" name="schema" value="backup">
-							<button type="submit" name="formsubmit"><?= $LANG['DOWNLOAD'] ?></button>
+			if($action == 'preformBackup'){
+				if ($collid && is_numeric($collid)) {
+					$dwcaHandler = new DwcArchiverCore();
+					$dwcaHandler->setCollArr($collid);
+					$dwcaHandler->setSchemaType('backup');
+					$dwcaHandler->setCharSetOut($cSet);
+					$dwcaHandler->setVerboseMode(2);
+					$dwcaHandler->setIncludeDets(1);
+					$dwcaHandler->setIncludeImgs(1);
+					$dwcaHandler->setIncludeAttributes(1);
+					$dwcaHandler->setIncludeMaterialSample(1);
+					$dwcaHandler->setIncludeIdentifiers(1);
+					$dwcaHandler->setIncludeAssociations(1);
+					$dwcaHandler->setRedactLocalities(0);
+					$archiveFile = $dwcaHandler->createDwcArchive();
+
+					if ($archiveFile) {
+						$filename = substr($archiveFile, strrpos($archiveFile, '/') + 1);
+						echo $LANG['BACKUP_FILE'] . ': <a href="collbackup.php?bufile=' . $filename . '">' . $filename . '</a>';
+					} else {
+						$errMsg = $dwcaHandler->getErrorMessage();
+						if($errMsg) echo $errMsg;
+						else echo $LANG['ERROR_CREATING_OUTPUT'];
+					}
+				}
+			}
+			else{
+				?>
+				<form name="buform" action="collbackup.php" method="post" onsubmit="">
+					<fieldset>
+						<legend><?= $LANG['DOWNLOAD_MODULE'] ?></legend>
+						<div style="height:50px; margin: 10px">
+							<input type="radio" id="cset1" name="cset" value="iso-8859-1" <?= ($cSet == 'iso88591' ? 'checked' : ''); ?> /> <label for="cset1">ISO-8859-1 (western)</label><br/>
+							<input type="radio" id="cset2" name="cset" value="utf-8" <?= (!$cSet || $cSet == 'utf8' ? 'checked' : ''); ?> /> <label for="cset2">UTF-8 (unicode)</label>
 						</div>
-						<div id="workingdiv" style="display:<?= ($action == 'Perform Backup' ? 'block' : 'none') ?>;">
-							<?= $LANG['DOWNLOADING'] ?>...
+						<div>
+							<div style="float:left">
+								<input type="hidden" name="collid" value="<?= $collid; ?>">
+								<button type="submit" name="formsubmit" value="preformBackup"><?= $LANG['DOWNLOAD'] ?></button>
+							</div>
 						</div>
-					</div>
-				</fieldset>
-			</form>
-			<?php
+					</fieldset>
+				</form>
+				<?php
+			}
 		}
 		?>
 	</div>

--- a/collections/misc/collprofiles.php
+++ b/collections/misc/collprofiles.php
@@ -665,7 +665,7 @@ if ($SYMB_UID) {
 								}
 								?>
 								<li style="margin-left:10px;">
-									<a href="#" onclick="newWindow = window.open('collbackup.php?collid=<?= $collid ?>','bucollid','scrollbars=1,toolbar=0,resizable=1,width=600,height=250,left=20,top=20');">
+									<a href="#" onclick="newWindow = window.open('collbackup.php?collid=<?= $collid ?>','bucollid','scrollbars=1,toolbar=0,resizable=1,width=700,height=450,left=20,top=20');">
 										<?= $LANG['BACKUP_DATA_FILE'] ?>
 									</a>
 								</li>

--- a/content/lang/collections/misc/collbackup.en.php
+++ b/content/lang/collections/misc/collbackup.en.php
@@ -5,8 +5,11 @@ Language: English
 ------------------
 */
 
+$LANG['OCCURRENCE_BAKUP_FILE'] = 'Symbiota Occurrence Backup File (DwC-Archive data package)';
 $LANG['OCCURRENCE_DOWNLOAD'] = 'Occurrences download';
 $LANG['DOWNLOAD_MODULE'] = 'Download Module';
+$LANG['BACKUP_FILE'] = 'Backup file';
+$LANG['ERROR_CREATING_OUTPUT'] = 'ERROR creating output file. Query probably did not include any records';
 $LANG['ENCODING'] = 'Data Set Encoding';
 $LANG['DOWNLOAD'] = 'Download';
 $LANG['DOWNLOADING'] = 'Downloading backup file';

--- a/content/lang/collections/misc/collbackup.en.php
+++ b/content/lang/collections/misc/collbackup.en.php
@@ -13,4 +13,5 @@ $LANG['ERROR_CREATING_OUTPUT'] = 'ERROR creating output file. Query probably did
 $LANG['ENCODING'] = 'Data Set Encoding';
 $LANG['DOWNLOAD'] = 'Download';
 $LANG['DOWNLOADING'] = 'Downloading backup file';
+$LANG['DOWNLOAD_COMPLETE'] = 'Backup file has been downloaded to your local system!';
 ?>

--- a/content/lang/collections/misc/collbackup.es.php
+++ b/content/lang/collections/misc/collbackup.es.php
@@ -13,4 +13,5 @@ $LANG['ERROR_CREATING_OUTPUT'] = 'Error al crear el archivo de salida. Es probab
 $LANG['ENCODING'] = 'Codificación de conjuntos de datos';
 $LANG['DOWNLOAD'] = 'Descargar';
 $LANG['DOWNLOADING'] = 'Descargando archivo de respaldo';
+$LANG['DOWNLOAD_COMPLETE'] = 'El archivo de copia de seguridad se ha descargado en su sistema local!';
 ?>

--- a/content/lang/collections/misc/collbackup.es.php
+++ b/content/lang/collections/misc/collbackup.es.php
@@ -5,9 +5,11 @@ Language: Español (Spanish)
 Translated by: Samanta Orellana (2021-08-18)
 ------------------
 */
-
+$LANG['OCCURRENCE_BAKUP_FILE'] = 'Archivo de respaldo de registros de Symbiota (paquete de datos DwC-Archive)';
 $LANG['OCCURRENCE_DOWNLOAD'] = 'Descarga de Ocurrencias';
 $LANG['DOWNLOAD_MODULE'] = 'Descargar Módulo';
+$LANG['BACKUP_FILE'] = 'Archivo de copia de seguridad';
+$LANG['ERROR_CREATING_OUTPUT'] = 'Error al crear el archivo de salida. Es probable que la consulta no haya incluido ningún registro';
 $LANG['ENCODING'] = 'Codificación de conjuntos de datos';
 $LANG['DOWNLOAD'] = 'Descargar';
 $LANG['DOWNLOADING'] = 'Descargando archivo de respaldo';

--- a/content/lang/collections/misc/collbackup.fr.php
+++ b/content/lang/collections/misc/collbackup.fr.php
@@ -13,4 +13,5 @@ $LANG['ERROR_CREATING_OUTPUT'] = "Erreur lors de la création du fichier de sort
 $LANG['ENCODING'] = "Encodage des ensembles de données";
 $LANG['DOWNLOAD'] = 'Télécharger';
 $LANG['DOWNLOADING'] = 'Téléchargement du Fichier de Sauvegarde';
+$LANG['DOWNLOAD_COMPLETE'] = 'Le fichier de sauvegarde a été téléchargé sur votre système local!';
 ?>

--- a/content/lang/collections/misc/collbackup.fr.php
+++ b/content/lang/collections/misc/collbackup.fr.php
@@ -5,9 +5,11 @@ Language: Français (French)
 ------------------
 */
 
-
+$LANG['OCCURRENCE_BAKUP_FILE'] = 'Fichier de sauvegarde des occurrences Symbiota (paquet de données DwC-Archive)';
 $LANG['OCCURRENCE_DOWNLOAD'] = 'Téléchargement des Occurrences';
 $LANG['DOWNLOAD_MODULE'] = 'Nodule à Télécharger';
+$LANG['BACKUP_FILE'] = 'Fichier de sauvegarde';
+$LANG['ERROR_CREATING_OUTPUT'] = "Erreur lors de la création du fichier de sortie. La requête n'a probablement renvoyé aucun enregistrement";
 $LANG['ENCODING'] = "Encodage des ensembles de données";
 $LANG['DOWNLOAD'] = 'Télécharger';
 $LANG['DOWNLOADING'] = 'Téléchargement du Fichier de Sauvegarde';

--- a/webservices/dwc/dwcapubhandler.php
+++ b/webservices/dwc/dwcapubhandler.php
@@ -101,7 +101,7 @@ if ($cond) {
 	}
 }
 if(!$collid && !$conditionApplied) exit('Filter conditions required');
-if(!$dwcaHandler->isAuthorized()){
+if(!$dwcaHandler->isAuthorized('dwcaPubHandler')){
 	//Basic lockdown of function to limited number of users until functionality is fully integrated into Symbiota 4.0 API with enhanced security applied
 	exit('Not authorized');
 }


### PR DESCRIPTION
- Improve efficiency of populating higher taxonomy data by limiting to hierarchy queries to use only the primary thesaurus (taxAuthID = 1)
- Add remote publication details and authorization method to omexport record. This is needed to track download activity made through dwcapubhandler.php webservice. 
- Convert data backups to verbose in order to avoid php-fpm timeouts. Output is now like the following screenshot, with a download link available to user. The other option would be to simply increase php-fmp timeouts, but is not idea. Ultimate, we will create an asynchronous download option that could be tracked via js, but that won't be implemented prior to 3.5.

<img width="1781" height="1383" alt="image" src="https://github.com/user-attachments/assets/49c42ee2-86cd-48b2-9366-b457d88da606" />

Addresses SSH issue https://github.com/Symbiota/Symbiota/issues/3690
and NEON Biorepo issue https://github.com/BioKIC/NEON-Biorepository/issues/1077


# Pull Request Checklist:
## Pre-Approval

- [x] Does the PR have a **release-notes-friendly title**?
- [x] There is a **description section** in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the the current `Hotfix-x.x.x` branch and PR'd into the same using the **squash & merge** option.

- [ ] All new **text** is preferably **internationalized** (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are **no linter errors**
- [ ] New features have **responsive design** (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [**Symbiota coding standards**](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an **autoformatter**), the reformat is its own, **separate commit** in the PR
- [x] Comment which **GitHub issue(s)**, if any does this PR address
- [ ] If this PR makes any changes that would require **additional configuration** of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are **detailed in [this document]**(https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing)
- [ ] If this **feature** has not been **documented** in [https://docs.symbiota.org/](https://docs.symbiota.org/) OR if changes are needed to the documentation, create a new github issue in [https://github.com/Symbiota/Symbiota/issues](https://github.com/Symbiota/Symbiota/issues) **labeled as documentation** and **add a link** to it herein.
- [x] If there are **merge conflicts** with this PR's **parent branch, resolve** them before marking the PR as ready for review.

## Post-Approval

- [ ] It is the code author's responsibility to **merge** their own pull request after it has been approved
- [ ] Remember to use the **squash & merge** option for a merge into the `Hotfix-x.x.x` branch
- [ ] Use the **merge** option (not squashed) for merges from the `hotfix` branch into the `master` branch.
  - [ ] a **subsequent PR from `master`** into `Development` should be made with the **merge** option (i.e., no squash)
  - [ ] **Immediately** **delete the `Hotfix-x.x.x` branch** and create a new `Hotfix-x.x.x+1` branch
  - [ ] **increment** the Symbiota **version** number in the symbase.php file and commit to the `Hotfix-x.x.x+1` branch

Thanks for contributing and keeping it clean!
